### PR TITLE
Use ClowdEnvironment config to set up FrontendEnvironment

### DIFF
--- a/config/ephemeral_config.json
+++ b/config/ephemeral_config.json
@@ -101,9 +101,6 @@
             }
         }
     },
-    "frontendEnv": {
-        "ingressClass": "openshift-default"
-    },
     "limitRange": {
         "spec": {
             "limits": [

--- a/config/local_config.json
+++ b/config/local_config.json
@@ -57,7 +57,8 @@
                 "mode": "minio"
             },
             "web": {
-                "mode": "operator",
+                "mode": "local",
+                "ingressClass": "nginx",
                 "port": 8000,
                 "privatePort": 10000
             },
@@ -100,9 +101,6 @@
                 "memory": "128Mi"
             }
         }
-    },
-    "frontendEnv": {
-        "ingressClass": "nginx"
     },
     "limitRange": {
         "spec": {

--- a/controllers/namespacereservation_controller.go
+++ b/controllers/namespacereservation_controller.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 
 	"fmt"
 	"math/rand"
@@ -248,9 +247,9 @@ func (r *NamespaceReservationReconciler) verifyClowdEnvForReadyNs(ctx context.Co
 		return err
 	}
 
-	ready, _ := r.NamespacePool.VerifyClowdEnv(ctx, r.Client, ns)
+	ready, _, _ := r.NamespacePool.GetClowdEnv(ctx, r.Client, ns)
 	if !ready {
-		return errors.New(fmt.Sprintf("ClowdEnvironment is not ready for namespace: %s", readyNsName))
+		return fmt.Errorf("ClowdEnvironment is not ready for namespace: %s", readyNsName)
 	}
 
 	return nil

--- a/controllers/pool.go
+++ b/controllers/pool.go
@@ -273,7 +273,8 @@ func (p *NamespacePool) createFrontendEnv(ctx context.Context, cl client.Client,
 		ingressDomain = ingressConfig.Spec.Domain
 	}
 
-	p.Config.FrontendEnvSpec.Hostname = fmt.Sprintf("%s.%s", ns.Name, ingressDomain)
+	clowdEnvironmentName := fmt.Sprintf("env-%s", ns.Name)
+	p.Config.FrontendEnvSpec.Hostname = fmt.Sprintf("%s.%s", clowdEnvironmentName, ingressDomain)
 	p.Config.FrontendEnvSpec.SSO = fmt.Sprintf("https://%s/auth/", p.Config.FrontendEnvSpec.Hostname)
 
 	frontendEnv := frontend.FrontendEnvironment{

--- a/controllers/pool.go
+++ b/controllers/pool.go
@@ -233,13 +233,13 @@ func (p *NamespacePool) verifyClowdEnvReady(env clowder.ClowdEnvironment) (bool,
 	conditions := env.Status.Conditions
 	for i := range conditions {
 		if conditions[i].Type == "DeploymentsReady" {
-			if conditions[i].Status == "True" {
-				return true, nil
+			if conditions[i].Status != "True" {
+				return false, errors.New("deployments not ready")
 			}
 		}
 	}
 
-	return false, errors.New("deployments not ready")
+	return true, nil
 }
 
 func (p *NamespacePool) GetClowdEnv(ctx context.Context, cl client.Client, ns core.Namespace) (bool, *clowder.ClowdEnvironment, error) {

--- a/controllers/pool.go
+++ b/controllers/pool.go
@@ -268,10 +268,11 @@ func (p *NamespacePool) createFrontendEnv(ctx context.Context, cl client.Client,
 
 	// make the hostnames and ingress class on the FrontendEnvironment match that of the ClowdEnvironment
 	// we already verified that the hostname was present in the ClowdEnvironment's status via 'verifyClowdEnvReady'
+	splitHostname := strings.Split(clowdEnv.Status.Hostname, ".")
 	frontendEnv := frontend.FrontendEnvironment{
 		Spec: frontend.FrontendEnvironmentSpec{
 			Hostname:     clowdEnv.Status.Hostname,
-			SSO:          fmt.Sprintf("https://%s/auth/", clowdEnv.Status.Hostname),
+			SSO:          fmt.Sprintf("https://%s-auth.%s/auth/", splitHostname[0], splitHostname[1:]),
 			IngressClass: clowdEnv.Spec.Providers.Web.IngressClass,
 		},
 	}

--- a/controllers/pool.go
+++ b/controllers/pool.go
@@ -432,7 +432,10 @@ func (p *NamespacePool) CreateOnDeckNamespace(ctx context.Context, cl client.Cli
 
 	}
 
+	// TODO: revisit this check
+	// We need to wait a bit before checking the clowdEnv
 	p.Log.Info("Verifying that the ClowdEnv is ready for namespace", "ns-name", ns.Name)
+	time.Sleep(10 * time.Second)
 	ready, clowdEnv, _ := p.GetClowdEnv(ctx, cl, ns)
 	for !ready || clowdEnv == nil {
 		p.Log.Info("Waiting on environment to be ready", "ns-name", ns.Name)


### PR DESCRIPTION
We will now fetch the ingressClass and hostname from the ClowdEnvironment:
* `ingressClass` comes from the ClowdEnvironment's `.spec.providers.web.ingressClass`
* `hostname` comes from the ClowdEnvironment's `.status.hostname`

If we see that the ClowdEnvironment's `.spec.providers.web.mode` is `local` then
* we will check to ensure the 'hostname' field is populated when we check if a ClowdEnvironment is ready
* we will provision a FrontendEnvironment

If the ClowdEnvironment's web mode is NOT local, a FrontendEnvironment is not provisioned by the ns operator.

This PR turns on 'local' mode for both the ephemeral and local ClowdEnvironment configs.