### PR TITLE
Fix sso URL string building, consider case of no domain, tweak not ready log msgs

### DIFF
--- a/controllers/pool.go
+++ b/controllers/pool.go
@@ -458,7 +458,7 @@ func (p *NamespacePool) CreateOnDeckNamespace(ctx context.Context, cl client.Cli
 		// env is not ready
 		msg := "ClowdEnvironment is not yet ready for namespace"
 		if err != nil {
-			msg = msg + fmt.Sprintf("(%s)", err)
+			msg = msg + fmt.Sprintf(" (%s)", err)
 		}
 		p.Log.Info(msg, "ns-name", ns.Name)
 	}


### PR DESCRIPTION
* ssoUrl was not rebuilding the string properly, fixed
* added logic to check if the ClowdEnvironment's hostname was not a FQDN
* tweak the log messaging during the pool's "waiting for ClowdEnvironment to be ready" loop to not log error msgs