### PR TITLE
[RHCLOUD-18364] Create non-prefixed shim services

### DIFF
--- a/controllers/pool.go
+++ b/controllers/pool.go
@@ -290,6 +290,9 @@ func (p *NamespacePool) createShimServices(ctx context.Context, cl client.Client
 		newSvc.SetName(serviceName)
 		newSvc.SetNamespace(ns.Name)
 		newSvc.Spec = origSvc.Spec
+		// empty the ClusterIPs so a new one is generated
+		newSvc.Spec.ClusterIP = ""
+		newSvc.Spec.ClusterIPs = []string{}
 		newSvc.SetOwnerReferences([]metav1.OwnerReference{
 			{
 				APIVersion: ns.APIVersion,

--- a/controllers/pool.go
+++ b/controllers/pool.go
@@ -281,7 +281,7 @@ func (p *NamespacePool) createShimServices(ctx context.Context, cl client.Client
 
 		err := cl.Get(ctx, nn, &origSvc)
 		if err != nil {
-			p.Log.Info("service %s not found in namespace, not creating shim for it", nn.Name)
+			p.Log.Info(fmt.Sprintf("service %s not found in namespace, not creating shim for it", serviceName), "ns-name", ns.Name)
 			continue
 		}
 
@@ -301,7 +301,7 @@ func (p *NamespacePool) createShimServices(ctx context.Context, cl client.Client
 
 		err = cl.Create(ctx, &newSvc)
 		if err != nil {
-			p.Log.Error(err, "failed to create shim service for '%s'", serviceName)
+			p.Log.Error(err, fmt.Sprintf("failed to create shim service for '%s'", serviceName), "ns-name", ns.Name)
 			return err
 		}
 	}


### PR DESCRIPTION
Until apps read the mbop/mocktitlements/keycloak hostnames via cdappconfig.json, we'll create a Service with a non-prefixed name in the namespace so that the name is predictable.