### PR TITLE
Add default selenium config options to ClowdEnvironment

### DIFF
--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -73,6 +73,22 @@
                 "k8sAccessLevel": "edit",
                 "configAccess": "environment",
                 "iqe": {
+                    "ui": {
+                        "selenium": {
+                            "imageBase": "quay.io/redhatqe/selenium-standalone",
+                            "defaultImageTag": "ff_91.5.1esr_gecko_v0.30.0_chrome_98.0.4758.80",
+                            "resources": {
+                                "limits": {
+                                    "cpu": "1",
+                                    "memory": "3Gi"
+                                },
+                                "requests": {
+                                    "cpu": "500m",
+                                    "memory": "512Mi"
+                                }
+                            }
+                        }
+                    },
                     "vaultSecretRef": {
                         "namespace": "ephemeral-base",
                         "name": "iqe-vault"

--- a/config/ephemeral_config.json
+++ b/config/ephemeral_config.json
@@ -73,6 +73,22 @@
                 "k8sAccessLevel": "edit",
                 "configAccess": "environment",
                 "iqe": {
+                    "ui": {
+                        "selenium": {
+                            "imageBase": "quay.io/redhatqe/selenium-standalone",
+                            "defaultImageTag": "ff_91.5.1esr_gecko_v0.30.0_chrome_98.0.4758.80",
+                            "resources": {
+                                "limits": {
+                                    "cpu": "1",
+                                    "memory": "3Gi"
+                                },
+                                "requests": {
+                                    "cpu": "500m",
+                                    "memory": "512Mi"
+                                }
+                            }
+                        }
+                    },
                     "vaultSecretRef": {
                         "namespace": "ephemeral-base",
                         "name": "iqe-vault"

--- a/config/local_config.json
+++ b/config/local_config.json
@@ -73,6 +73,22 @@
                 "k8sAccessLevel": "edit",
                 "configAccess": "environment",
                 "iqe": {
+                    "ui": {
+                        "selenium": {
+                            "imageBase": "quay.io/redhatqe/selenium-standalone",
+                            "defaultImageTag": "ff_91.5.1esr_gecko_v0.30.0_chrome_98.0.4758.80",
+                            "resources": {
+                                "limits": {
+                                    "cpu": "1",
+                                    "memory": "3Gi"
+                                },
+                                "requests": {
+                                    "cpu": "500m",
+                                    "memory": "512Mi"
+                                }
+                            }
+                        }
+                    },
                     "vaultSecretRef": {
                         "namespace": "ephemeral-base",
                         "name": "iqe-vault"


### PR DESCRIPTION
Adds config similar to this: https://github.com/RedHatInsights/clowder/blob/master/bundle/tests/scorecard/kuttl/test-iqe-jobs-selenium/01-pods.yaml#L24-L34

for setting the default selenium options.

The resource limits come from what we've used on selenium containers in insights-pipeline-lib ... https://github.com/RedHatInsights/insights-pipeline-lib/blob/master/vars/openShiftUtils.groovy#L195-L198