### PR TITLE
Removed Unused Annotations/Labels

### DIFF
--- a/controllers/cloud.redhat.com/namespaces.go
+++ b/controllers/cloud.redhat.com/namespaces.go
@@ -20,9 +20,8 @@ import (
 )
 
 var initialAnnotations = map[string]string{
-	"status":      "creating", // TODO: Remove this annotation after Bonfire is updated
-	"env-status":  "creating",
-	"operator-ns": "true",
+	"status":     "creating", // TODO: Remove this annotation after Bonfire is updated
+	"env-status": "creating",
 }
 
 var initialLabels = map[string]string{


### PR DESCRIPTION
We made the `operator-ns` annotation a label instead. This PR is to cleanup the old `operator-ns` annotation. Additionally, we changed the name of the `status` label to `env-status` so I removed the old `status` label.