### PR TITLE
removed unused annotations

### DIFF
--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -59,10 +59,10 @@ func (r *ClowdenvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 		if err := CreateFrontendEnv(ctx, r.Client, ns, env); err != nil {
 			r.Log.Error(err, "Error encountered with frontend environment", "ns-name", ns)
-			UpdateAnnotations(ctx, r.Client, map[string]string{"env-status": "error", "status": "error"}, ns)
+			UpdateAnnotations(ctx, r.Client, map[string]string{"env-status": "error"}, ns)
 		} else {
 			r.Log.Info("Namespace ready", "ns-name", ns)
-			UpdateAnnotations(ctx, r.Client, map[string]string{"env-status": "ready", "status": "ready"}, ns)
+			UpdateAnnotations(ctx, r.Client, map[string]string{"env-status": "ready"}, ns)
 		}
 	}
 

--- a/controllers/cloud.redhat.com/namespaces.go
+++ b/controllers/cloud.redhat.com/namespaces.go
@@ -20,9 +20,8 @@ import (
 )
 
 var initialAnnotations = map[string]string{
-	"status":      "creating", // TODO: Remove this annotation after Bonfire is updated
-	"env-status":  "creating",
-	"operator-ns": "true",
+	"status":     "creating", // TODO: Remove this annotation after Bonfire is updated
+	"env-status": "creating",
 }
 
 var initialLabels = map[string]string{

--- a/controllers/cloud.redhat.com/namespaces.go
+++ b/controllers/cloud.redhat.com/namespaces.go
@@ -245,7 +245,7 @@ func CopySecrets(ctx context.Context, cl client.Client, nsName string) error {
 }
 
 func DeleteNamespace(ctx context.Context, cl client.Client, nsName string) error {
-	UpdateAnnotations(ctx, cl, map[string]string{"env-status": "deleting", "status": "deleting"}, nsName)
+	UpdateAnnotations(ctx, cl, map[string]string{"env-status": "deleting"}, nsName)
 
 	ns, err := GetNamespace(ctx, cl, nsName)
 	if err != nil {

--- a/controllers/cloud.redhat.com/namespaces.go
+++ b/controllers/cloud.redhat.com/namespaces.go
@@ -20,7 +20,6 @@ import (
 )
 
 var initialAnnotations = map[string]string{
-	"status":     "creating", // TODO: Remove this annotation after Bonfire is updated
 	"env-status": "creating",
 }
 

--- a/controllers/cloud.redhat.com/pool_controller.go
+++ b/controllers/cloud.redhat.com/pool_controller.go
@@ -78,7 +78,7 @@ func (r *NamespacePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			r.Log.Info("Setting up new namespace", "ns-name", nsName, "pool-type", pool.Name)
 			if err := SetupNamespace(ctx, r.Client, pool, nsName); err != nil {
 				r.Log.Error(err, "Error while setting up namespace", "ns-name", nsName)
-				if err := UpdateAnnotations(ctx, r.Client, map[string]string{"status": "error"}, nsName); err != nil {
+				if err := UpdateAnnotations(ctx, r.Client, map[string]string{"env-status": "error"}, nsName); err != nil {
 					r.Log.Error(err, "Error while updating annotations on namespace", "ns-name", nsName)
 					// Last resort - if annotations can't be updated attempt manual deletion of namespace
 					ns, err := GetNamespace(ctx, r.Client, nsName)


### PR DESCRIPTION
The objective for this PR was to remove a couple annotations not needed anymore. I removed `operator-ns` from the default annotations because we made it a label instead. Additionally, I removed the `status` annotation because it was renamed to `env-status`. 