### PR TITLE
Updates for prometheus operator cleanup.

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -112,6 +112,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - operators.coreos.com
+  resources:
+  - operators
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - project.openshift.io
   resources:
   - projectrequests

--- a/controllers/cloud.redhat.com/namespacereservation_controller.go
+++ b/controllers/cloud.redhat.com/namespacereservation_controller.go
@@ -112,6 +112,8 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 			if err != nil {
 				r.Log.Error(err, fmt.Sprintf("Error deleting prometheus.%s", res.Status.Namespace))
 				return ctrl.Result{Requeue: true}, err
+			} else {
+				r.Log.Info("Successfully deleting", "prometheus-operator", fmt.Sprintf("prometheus.%s", res.Status.Namespace))
 			}
 
 			if err := r.Client.Delete(ctx, &res); err != nil {

--- a/controllers/cloud.redhat.com/poller.go
+++ b/controllers/cloud.redhat.com/poller.go
@@ -7,6 +7,7 @@ import (
 
 	crd "github.com/RedHatInsights/ephemeral-namespace-operator/apis/cloud.redhat.com/v1alpha1"
 	"github.com/go-logr/logr"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,11 +48,11 @@ func (p *Poller) Poll() error {
 
 				p.Log.Info("Reservation scheduled for deletion, deleting", "prometheus-operator", fmt.Sprintf("prometheus.%s", res.Status.Namespace))
 				err := DeletePrometheusOperator(ctx, p.Client, res.Status.Namespace)
-				if err != nil {
+				if k8serr.IsNotFound(err) {
 					p.Log.Error(err, fmt.Sprintf("Error deleting prometheus.%s", res.Status.Namespace))
 					return err
 				} else {
-					p.Log.Info("Successfully deleting", "prometheus-operator", fmt.Sprintf("prometheus.%s", res.Status.Namespace))
+					p.Log.Info("Successfully deleted", "prometheus-operator", fmt.Sprintf("prometheus.%s", res.Status.Namespace))
 				}
 
 				if err := p.Client.Delete(ctx, &res); err != nil {

--- a/controllers/cloud.redhat.com/pool_controller.go
+++ b/controllers/cloud.redhat.com/pool_controller.go
@@ -141,7 +141,7 @@ func (r *NamespacePoolReconciler) handleErrorNamespaces(ctx context.Context, err
 			r.Log.Error(err, fmt.Sprintf("Error deleting prometheus.%s", nsName))
 			return fmt.Errorf("handleErrorNamespace error: Couldn't delete prometheus operator: %v", err)
 		} else {
-			r.Log.Info("Successfully deleting", "prometheus-operator", fmt.Sprintf("prometheus.%s", r.Status.Namespace))
+			r.Log.Info("Successfully deleting", "prometheus-operator", fmt.Sprintf("prometheus.%s", nsName))
 		}
 	}
 

--- a/controllers/cloud.redhat.com/pool_controller.go
+++ b/controllers/cloud.redhat.com/pool_controller.go
@@ -140,6 +140,8 @@ func (r *NamespacePoolReconciler) handleErrorNamespaces(ctx context.Context, err
 		if err != nil {
 			r.Log.Error(err, fmt.Sprintf("Error deleting prometheus.%s", nsName))
 			return fmt.Errorf("handleErrorNamespace error: Couldn't delete prometheus operator: %v", err)
+		} else {
+			r.Log.Info("Successfully deleting", "prometheus-operator", fmt.Sprintf("prometheus.%s", r.Status.Namespace))
 		}
 	}
 


### PR DESCRIPTION
In this PR, I added deletion of the prometheus operator at the moment that reservation is deleted (When a user run `bonfire namespace release`). I left the other areas for prometheus operator cleanup to handle any cases outside of a user using Bonfire to remove a namespace. 

It looks like my last PR that had the changes from adding the RBAC marker did not update the `config/rbac/role.yaml` file so I have pushed that with the other changes. 

I also added log messages displaying the successful deletion of the prometheus operator. 