### PR TITLE
Revert "Removed 'env-' from clowdenv name"

### DIFF
--- a/controllers/cloud.redhat.com/helpers/clowdenvs.go
+++ b/controllers/cloud.redhat.com/helpers/clowdenvs.go
@@ -17,7 +17,7 @@ func CreateClowdEnv(ctx context.Context, cl client.Client, spec clowder.ClowdEnv
 	env := clowder.ClowdEnvironment{
 		Spec: spec,
 	}
-	env.SetName(nsName)
+	env.SetName(fmt.Sprintf("env-%s", nsName))
 	env.Spec.TargetNamespace = nsName
 
 	ns, err := GetNamespace(ctx, cl, nsName)
@@ -67,7 +67,7 @@ func WaitForClowdEnv(ctx context.Context, cl client.Client, log logr.Logger, nsN
 func GetClowdEnv(ctx context.Context, cl client.Client, nsName string) (bool, *clowder.ClowdEnvironment, error) {
 	env := clowder.ClowdEnvironment{}
 	nn := types.NamespacedName{
-		Name:      nsName,
+		Name:      fmt.Sprintf("env-%s", nsName),
 		Namespace: nsName,
 	}
 

--- a/controllers/cloud.redhat.com/helpers/frontends.go
+++ b/controllers/cloud.redhat.com/helpers/frontends.go
@@ -17,7 +17,7 @@ import (
 
 func CreateFrontendEnv(ctx context.Context, cl client.Client, nsName string, clowdEnv clowder.ClowdEnvironment) error {
 	frontendEnv := frontend.FrontendEnvironment{}
-	err := cl.Get(ctx, types.NamespacedName{Name: nsName}, &frontendEnv)
+	err := cl.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("env-%s", nsName)}, &frontendEnv)
 
 	// if frontendEnv not found create it
 	if err != nil && k8serr.IsNotFound(err) {
@@ -50,7 +50,7 @@ func CreateFrontendEnv(ctx context.Context, cl client.Client, nsName string, clo
 			return err
 		}
 
-		frontendEnv.SetName(ns.Name)
+		frontendEnv.SetName(fmt.Sprintf("env-%s", ns.Name))
 		frontendEnv.SetOwnerReferences([]metav1.OwnerReference{
 			{
 				APIVersion: ns.APIVersion,


### PR DESCRIPTION
Reverts RedHatInsights/ephemeral-namespace-operator#148