### PR TITLE
[RHCLOUD-21372] Fixed log issue showing reconciling error

### DIFF
--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -60,24 +60,24 @@ func (r *ClowdenvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		"deployments", fmt.Sprintf("%d / %d", env.Status.Deployments.ReadyDeployments, env.Status.Deployments.ManagedDeployments),
 	)
 
-	nsName := env.Spec.TargetNamespace
-	r.Log.Info("clowdenvironment ready", "namespace", nsName)
+	namespaceName := env.Spec.TargetNamespace
+	r.Log.Info("clowdenvironment ready", "namespace", namespaceName)
 
-	if err := helpers.CreateFrontendEnv(ctx, r.Client, nsName, env); err != nil {
-		r.Log.Error(err, "error encountered with frontend environment", "namespace", nsName)
-		if aerr := helpers.UpdateAnnotations(ctx, r.Client, nsName, helpers.AnnotationEnvError.ToMap()); aerr != nil {
+	if err := helpers.CreateFrontendEnv(ctx, r.Client, namespaceName, env); err != nil {
+		r.Log.Error(err, "error encountered with frontend environment", "namespace", namespaceName)
+		if aerr := helpers.UpdateAnnotations(ctx, r.Client, namespaceName, helpers.AnnotationEnvError.ToMap()); aerr != nil {
 			return ctrl.Result{Requeue: true}, fmt.Errorf("error setting annotations: %w", aerr)
 		}
 	}
 
-	r.Log.Info("namespace ready", "namespace", nsName)
-	if err := helpers.UpdateAnnotations(ctx, r.Client, nsName, helpers.AnnotationEnvReady.ToMap()); err != nil {
+	r.Log.Info("namespace ready", "namespace", namespaceName)
+	if err := helpers.UpdateAnnotations(ctx, r.Client, namespaceName, helpers.AnnotationEnvReady.ToMap()); err != nil {
 		return ctrl.Result{Requeue: true}, fmt.Errorf("error setting annotations: %w", err)
 	}
 
-	namespace, err := helpers.GetNamespace(ctx, r.Client, nsName)
+	namespace, err := helpers.GetNamespace(ctx, r.Client, namespaceName)
 	if err != nil {
-		r.Log.Error(err, "could not retrieve updated resource", "namespace", nsName)
+		return ctrl.Result{Requeue: true}, fmt.Errorf("could not retrieve updated namespace %s: %w", namespaceName, err)
 	}
 
 	if _, ok := namespace.Annotations[helpers.CompletionTime]; ok {
@@ -89,12 +89,12 @@ func (r *ClowdenvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	err = helpers.UpdateAnnotations(ctx, r.Client, namespace.Name, AnnotationCompletionTime.ToMap())
 	if err != nil {
-		r.Log.Error(err, "could not update annotation with completion time", "namespace", nsName)
+		return ctrl.Result{Requeue: true}, fmt.Errorf("could not retrieve updated namespace %s after updating annotations: %w", namespaceName, err)
 	}
 
-	namespace, err = helpers.GetNamespace(ctx, r.Client, nsName)
+	namespace, err = helpers.GetNamespace(ctx, r.Client, namespaceName)
 	if err != nil {
-		r.Log.Error(err, "could not retrieve newly created namespace", "namespace", nsName)
+		r.Log.Error(err, "could not retrieve newly created namespace", "namespace", namespaceName)
 	}
 
 	if err := r.Client.Update(ctx, &namespace); err != nil {

--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -50,15 +50,15 @@ func (r *ClowdenvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
+	if ready, err := helpers.VerifyClowdEnvReady(env); !ready {
+		return ctrl.Result{Requeue: true}, err
+	}
+
 	r.Log.Info(
 		"Reconciling clowdenv",
 		"env-name", env.Name,
 		"deployments", fmt.Sprintf("%d / %d", env.Status.Deployments.ReadyDeployments, env.Status.Deployments.ManagedDeployments),
 	)
-
-	if ready, err := helpers.VerifyClowdEnvReady(env); !ready {
-		return ctrl.Result{Requeue: true}, err
-	}
 
 	nsName := env.Spec.TargetNamespace
 	r.Log.Info("clowdenvironment ready", "namespace", nsName)
@@ -75,30 +75,35 @@ func (r *ClowdenvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{Requeue: true}, fmt.Errorf("error setting annotations: %w", err)
 	}
 
-	ns, err := helpers.GetNamespace(ctx, r.Client, nsName)
+	namespace, err := helpers.GetNamespace(ctx, r.Client, nsName)
 	if err != nil {
 		r.Log.Error(err, "could not retrieve newly created namespace", "namespace", nsName)
 	}
 
-	if _, ok := ns.Annotations[helpers.CompletionTime]; ok {
+	if _, ok := namespace.Annotations[helpers.CompletionTime]; ok {
 		return ctrl.Result{}, nil
 	}
 
 	nsCompletionTime := time.Now()
 	var AnnotationCompletionTime = helpers.CustomAnnotation{Annotation: helpers.CompletionTime, Value: nsCompletionTime.String()}
 
-	err = helpers.UpdateAnnotations(ctx, r.Client, ns.Name, AnnotationCompletionTime.ToMap())
+	err = helpers.UpdateAnnotations(ctx, r.Client, namespace.Name, AnnotationCompletionTime.ToMap())
 	if err != nil {
 		r.Log.Error(err, "could not update annotation with completion time", "namespace", nsName)
 	}
 
-	if err := r.Client.Update(ctx, &ns); err != nil {
+	namespace, err = helpers.GetNamespace(ctx, r.Client, nsName)
+	if err != nil {
+		r.Log.Error(err, "could not retrieve newly created namespace", "namespace", nsName)
+	}
+
+	if err := r.Client.Update(ctx, &namespace); err != nil {
 		return ctrl.Result{Requeue: true}, err
 	}
 
-	elapsed := nsCompletionTime.Sub(ns.CreationTimestamp.Time)
+	elapsed := nsCompletionTime.Sub(namespace.CreationTimestamp.Time)
 
-	averageNamespaceCreationMetrics.With(prometheus.Labels{"pool": ns.Labels["pool"]}).Observe(float64(elapsed.Seconds()))
+	averageNamespaceCreationMetrics.With(prometheus.Labels{"pool": namespace.Labels["pool"]}).Observe(float64(elapsed.Seconds()))
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -77,7 +77,7 @@ func (r *ClowdenvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	namespace, err := helpers.GetNamespace(ctx, r.Client, nsName)
 	if err != nil {
-		r.Log.Error(err, "could not retrieve newly created namespace", "namespace", nsName)
+		r.Log.Error(err, "could not retrieve updated resource", "namespace", nsName)
 	}
 
 	if _, ok := namespace.Annotations[helpers.CompletionTime]; ok {

--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -93,7 +93,7 @@ func (r *ClowdenvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	if err := r.Client.Update(ctx, &ns); err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{Requeue: true}, err
 	}
 
 	elapsed := nsCompletionTime.Sub(ns.CreationTimestamp.Time)

--- a/controllers/cloud.redhat.com/helpers/clowdenvs.go
+++ b/controllers/cloud.redhat.com/helpers/clowdenvs.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	clowder "github.com/RedHatInsights/clowder/apis/cloud.redhat.com/v1alpha1"
-	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,29 +37,6 @@ func CreateClowdEnv(ctx context.Context, cl client.Client, spec clowder.ClowdEnv
 	}
 
 	return nil
-}
-
-func WaitForClowdEnv(ctx context.Context, cl client.Client, log logr.Logger, nsName string) *clowder.ClowdEnvironment {
-	var clowdEnv *clowder.ClowdEnvironment
-	var ready bool
-	var err error
-	for {
-		time.Sleep(10 * time.Second)
-
-		ready, clowdEnv, err = GetClowdEnv(ctx, cl, nsName)
-		if ready && clowdEnv != nil {
-			break
-		}
-
-		// env is not ready
-		msg := "ClowdEnvironment is not yet ready for namespace"
-		if err != nil {
-			msg += fmt.Sprintf(" (%s)", err)
-		}
-		log.Info(msg, "namespace", nsName)
-	}
-
-	return clowdEnv
 }
 
 func GetClowdEnv(ctx context.Context, cl client.Client, nsName string) (bool, *clowder.ClowdEnvironment, error) {
@@ -101,10 +76,10 @@ func VerifyClowdEnvReady(env clowder.ClowdEnvironment) (bool, error) {
 	}
 
 	if !reconciliationSuccessful {
-		return false, errors.New("reconciliation not successful")
+		return false, nil
 	}
 	if !deploymentsReady {
-		return false, errors.New("deployments not ready")
+		return false, nil
 	}
 
 	return true, nil

--- a/controllers/cloud.redhat.com/helpers/clowdenvs.go
+++ b/controllers/cloud.redhat.com/helpers/clowdenvs.go
@@ -62,10 +62,11 @@ func VerifyClowdEnvReady(env clowder.ClowdEnvironment) (bool, error) {
 		return false, errors.New("hostname not populated")
 	}
 
-	// check that all deployments are ready
 	conditions := env.Status.Conditions
+
 	reconciliationSuccessful := false
 	deploymentsReady := false
+
 	for i := range conditions {
 		if conditions[i].Type == "ReconciliationSuccessful" && conditions[i].Status == "True" {
 			reconciliationSuccessful = true
@@ -75,12 +76,5 @@ func VerifyClowdEnvReady(env clowder.ClowdEnvironment) (bool, error) {
 		}
 	}
 
-	if !reconciliationSuccessful {
-		return false, nil
-	}
-	if !deploymentsReady {
-		return false, nil
-	}
-
-	return true, nil
+	return (reconciliationSuccessful && deploymentsReady), nil
 }

--- a/controllers/cloud.redhat.com/helpers/namespaces.go
+++ b/controllers/cloud.redhat.com/helpers/namespaces.go
@@ -144,7 +144,7 @@ func UpdateAnnotations(ctx context.Context, cl client.Client, nsName string, ann
 	utils.UpdateAnnotations(&ns, annotations)
 
 	if err := cl.Update(ctx, &ns); err != nil {
-		return err
+		return fmt.Errorf("there was issue updating annotations for namespace [%s]", ns.Name)
 	}
 
 	return nil

--- a/controllers/cloud.redhat.com/namespacepool_controller.go
+++ b/controllers/cloud.redhat.com/namespacepool_controller.go
@@ -94,6 +94,11 @@ func (r *NamespacePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
+	if err := r.Client.Get(ctx, req.NamespacedName, &pool); err != nil {
+		r.Log.Error(err, fmt.Sprintf("cannot retrieve [%s] pool resource", pool.Name))
+		return ctrl.Result{Requeue: true}, err
+	}
+
 	if err := r.Status().Update(ctx, &pool); err != nil {
 		r.Log.Error(err, fmt.Sprintf("cannot update [%s] pool status", pool.Name))
 		return ctrl.Result{}, err
@@ -196,8 +201,6 @@ func (r *NamespacePoolReconciler) getNamespaceQuantityDelta(pool crd.NamespacePo
 
 	if namespaceDelta == 0 && isAtLimit {
 		r.Log.Info(fmt.Sprintf("max number of namespaces for pool [%s] already created", pool.Name), "max namespaces", poolSizeLimit)
-	} else {
-		r.Log.Info(fmt.Sprintf("Namespaces should change by [%s]", pool.Name))
 	}
 
 	return namespaceDelta

--- a/controllers/cloud.redhat.com/namespacepool_controller.go
+++ b/controllers/cloud.redhat.com/namespacepool_controller.go
@@ -94,11 +94,6 @@ func (r *NamespacePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	if err := r.Client.Get(ctx, req.NamespacedName, &pool); err != nil {
-		r.Log.Error(err, fmt.Sprintf("cannot retrieve [%s] pool resource", pool.Name))
-		return ctrl.Result{Requeue: true}, err
-	}
-
 	if err := r.Status().Update(ctx, &pool); err != nil {
 		r.Log.Error(err, fmt.Sprintf("cannot update [%s] pool status", pool.Name))
 		return ctrl.Result{}, err


### PR DESCRIPTION
If checking for ClowdEnvironment ready status returned `false`, the function would return an error. This error would occur at every reconcile while waiting for the ClowdEnvironment to be ready. This caused the log message to be printed consistently until it was ready. 

Additionally, the `WaitForClowdEnv` function was never actually being used so it was removed. 