### PR TITLE
[WIP] Rogue namespaces bug fix, Namespace annotations aren't updating

### DIFF
--- a/controllers/cloud.redhat.com/helpers/namespaces.go
+++ b/controllers/cloud.redhat.com/helpers/namespaces.go
@@ -143,10 +143,6 @@ func UpdateAnnotations(ctx context.Context, cl client.Client, namespaceName stri
 
 	utils.UpdateAnnotations(&namespace, annotations)
 
-	if err := cl.Get(ctx, types.NamespacedName{Name: namespaceName}, &namespace); err != nil {
-		return fmt.Errorf("there was an issue retrieving namespace [%s] with newly added annotations", namespaceName)
-	}
-
 	if err := cl.Update(ctx, &namespace); err != nil {
 		return fmt.Errorf("there was an issue updating annotations for namespace [%s]", namespaceName)
 	}

--- a/controllers/cloud.redhat.com/helpers/namespaces.go
+++ b/controllers/cloud.redhat.com/helpers/namespaces.go
@@ -144,11 +144,11 @@ func UpdateAnnotations(ctx context.Context, cl client.Client, namespaceName stri
 	utils.UpdateAnnotations(&namespace, annotations)
 
 	if err := cl.Get(ctx, types.NamespacedName{Name: namespaceName}, &namespace); err != nil {
-		return fmt.Errorf("there was issue retrieving namespace [%s] with newly added annotations", namespaceName)
+		return fmt.Errorf("there was an issue retrieving namespace [%s] with newly added annotations", namespaceName)
 	}
 
 	if err := cl.Update(ctx, &namespace); err != nil {
-		return fmt.Errorf("there was issue updating annotations for namespace [%s]", namespaceName)
+		return fmt.Errorf("there was an issue updating annotations for namespace [%s]", namespaceName)
 	}
 
 	return nil

--- a/controllers/cloud.redhat.com/helpers/namespaces.go
+++ b/controllers/cloud.redhat.com/helpers/namespaces.go
@@ -143,9 +143,17 @@ func UpdateAnnotations(ctx context.Context, cl client.Client, namespaceName stri
 
 	utils.UpdateAnnotations(&namespace, annotations)
 
-	if err := cl.Update(ctx, &namespace); err != nil {
-		return fmt.Errorf("there was an issue updating annotations for namespace [%s]", namespaceName)
-	}
+	err = retry.OnError(
+		wait.Backoff(retry.DefaultBackoff),
+		func(error) bool { return true },
+		func() error {
+			if err = cl.Update(ctx, &namespace); err != nil {
+				return fmt.Errorf("there was an issue updating annotations for namespace [%s]", namespaceName)
+			}
+
+			return nil
+		},
+	)
 
 	return nil
 }

--- a/controllers/cloud.redhat.com/helpers/namespaces.go
+++ b/controllers/cloud.redhat.com/helpers/namespaces.go
@@ -144,7 +144,7 @@ func UpdateAnnotations(ctx context.Context, cl client.Client, namespaceName stri
 	utils.UpdateAnnotations(&namespace, annotations)
 
 	err = retry.RetryOnConflict(
-		wait.Backoff(retry.DefaultBackoff),
+		retry.DefaultBackoff,
 		func() error {
 			if err = cl.Update(ctx, &namespace); err != nil {
 				return fmt.Errorf("there was an issue updating annotations for namespace [%s]", namespaceName)

--- a/controllers/cloud.redhat.com/helpers/namespaces.go
+++ b/controllers/cloud.redhat.com/helpers/namespaces.go
@@ -135,16 +135,20 @@ func CheckReadyStatus(pool string, ns core.Namespace, ready []core.Namespace) []
 	return ready
 }
 
-func UpdateAnnotations(ctx context.Context, cl client.Client, nsName string, annotations map[string]string) error {
-	ns, err := GetNamespace(ctx, cl, nsName)
+func UpdateAnnotations(ctx context.Context, cl client.Client, namespaceName string, annotations map[string]string) error {
+	namespace, err := GetNamespace(ctx, cl, namespaceName)
 	if err != nil {
 		return err
 	}
 
-	utils.UpdateAnnotations(&ns, annotations)
+	utils.UpdateAnnotations(&namespace, annotations)
 
-	if err := cl.Update(ctx, &ns); err != nil {
-		return fmt.Errorf("there was issue updating annotations for namespace [%s]", ns.Name)
+	if err := cl.Get(ctx, types.NamespacedName{Name: namespaceName}, &namespace); err != nil {
+		return fmt.Errorf("there was issue retrieving namespace [%s] with newly added annotations", namespaceName)
+	}
+
+	if err := cl.Update(ctx, &namespace); err != nil {
+		return fmt.Errorf("there was issue updating annotations for namespace [%s]", namespaceName)
 	}
 
 	return nil

--- a/controllers/cloud.redhat.com/helpers/namespaces.go
+++ b/controllers/cloud.redhat.com/helpers/namespaces.go
@@ -143,9 +143,8 @@ func UpdateAnnotations(ctx context.Context, cl client.Client, namespaceName stri
 
 	utils.UpdateAnnotations(&namespace, annotations)
 
-	err = retry.OnError(
+	err = retry.RetryOnConflict(
 		wait.Backoff(retry.DefaultBackoff),
-		func(error) bool { return true },
 		func() error {
 			if err = cl.Update(ctx, &namespace); err != nil {
 				return fmt.Errorf("there was an issue updating annotations for namespace [%s]", namespaceName)


### PR DESCRIPTION
Attempting a retry on error to ensure that any changes the Kubernetes API make to a project is finished before we attempt to update the annotations of that same namespace. 