### PR TITLE
rid for tracing reconciliation log output

### DIFF
--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	clowder "github.com/RedHatInsights/clowder/apis/cloud.redhat.com/v1alpha1"
-	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/errors"
 	"github.com/RedHatInsights/ephemeral-namespace-operator/controllers/cloud.redhat.com/helpers"
 	"github.com/RedHatInsights/rhc-osdk-utils/utils"
 	"github.com/go-logr/logr"
@@ -47,7 +46,6 @@ type ClowdenvironmentReconciler struct {
 
 func (r *ClowdenvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.log.WithValues("rid", utils.RandString(5))
-	ctx = context.WithValue(ctx, errors.ClowdKey("log"), &log)
 
 	env := clowder.ClowdEnvironment{}
 	if err := r.client.Get(ctx, req.NamespacedName, &env); err != nil {

--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -37,6 +37,7 @@ import (
 // ClowdenvironmentReconciler reconciles a Clowdenvironment object
 type ClowdenvironmentReconciler struct {
 	client client.Client
+	ctx    context.Context
 	scheme *runtime.Scheme
 	log    logr.Logger
 }

--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -37,7 +37,6 @@ import (
 // ClowdenvironmentReconciler reconciles a Clowdenvironment object
 type ClowdenvironmentReconciler struct {
 	client client.Client
-	ctx    context.Context
 	scheme *runtime.Scheme
 	log    logr.Logger
 }

--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -46,6 +46,7 @@ type ClowdenvironmentReconciler struct {
 
 func (r *ClowdenvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.log.WithValues("rid", utils.RandString(5))
+	ctx = context.WithValue(ctx, helpers.ErrType("log"), &log)
 
 	env := clowder.ClowdEnvironment{}
 	if err := r.client.Get(ctx, req.NamespacedName, &env); err != nil {

--- a/controllers/cloud.redhat.com/helpers/types.go
+++ b/controllers/cloud.redhat.com/helpers/types.go
@@ -41,3 +41,5 @@ var AnnotationReservedTrue = CustomAnnotation{Annotation: AnnotationReserved, Va
 var AnnotationReservedFalse = CustomAnnotation{Annotation: AnnotationReserved, Value: FalseValue}
 
 var LabelOperatorNamespaceTrue = CustomLabel{Label: LabelOperatorNS, Value: TrueValue}
+
+type ErrType string

--- a/controllers/cloud.redhat.com/namespacepool_controller.go
+++ b/controllers/cloud.redhat.com/namespacepool_controller.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/errors"
 	crd "github.com/RedHatInsights/ephemeral-namespace-operator/apis/cloud.redhat.com/v1alpha1"
 	"github.com/RedHatInsights/ephemeral-namespace-operator/controllers/cloud.redhat.com/helpers"
 	"github.com/RedHatInsights/rhc-osdk-utils/utils"
@@ -49,7 +48,7 @@ type NamespacePoolReconciler struct {
 
 func (r *NamespacePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.log.WithValues("rid", utils.RandString(5))
-	ctx = context.WithValue(ctx, errors.ClowdKey("log"), &log)
+	ctx = context.WithValue(ctx, helpers.ErrType("log"), &log)
 
 	pool := crd.NamespacePool{}
 

--- a/controllers/cloud.redhat.com/namespacepool_controller.go
+++ b/controllers/cloud.redhat.com/namespacepool_controller.go
@@ -30,8 +30,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/errors"
 	crd "github.com/RedHatInsights/ephemeral-namespace-operator/apis/cloud.redhat.com/v1alpha1"
 	"github.com/RedHatInsights/ephemeral-namespace-operator/controllers/cloud.redhat.com/helpers"
+	"github.com/RedHatInsights/rhc-osdk-utils/utils"
 )
 
 // NamespacePoolReconciler reconciles a NamespacePool object
@@ -46,21 +48,24 @@ type NamespacePoolReconciler struct {
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=namespacepools/finalizers,verbs=update
 
 func (r *NamespacePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.log.WithValues("rid", utils.RandString(5))
+	ctx = context.WithValue(ctx, errors.ClowdKey("log"), &log)
+
 	pool := crd.NamespacePool{}
 
 	if err := r.client.Get(ctx, req.NamespacedName, &pool); err != nil {
-		r.log.Error(err, fmt.Sprintf("cannot retrieve [%s] pool resource", pool.Name))
+		log.Error(err, fmt.Sprintf("cannot retrieve [%s] pool resource", pool.Name))
 		return ctrl.Result{Requeue: true}, err
 	}
 
 	errNamespaceList, err := r.getPoolStatus(ctx, &pool)
 	if err != nil {
-		r.log.Error(err, "unable to get status of owned namespaces")
+		log.Error(err, "unable to get status of owned namespaces")
 		return ctrl.Result{Requeue: true}, err
 	}
 
 	if len(errNamespaceList) > 0 {
-		r.log.Info(fmt.Sprintf("[%d] namespaces in error state are queued for deletion", len(errNamespaceList)))
+		log.Info(fmt.Sprintf("[%d] namespaces in error state are queued for deletion", len(errNamespaceList)))
 		err = r.deleteErrorNamespaces(ctx, errNamespaceList)
 		if err != nil {
 			r.log.Error(err, "Unable to delete namespaces in error state")
@@ -68,7 +73,7 @@ func (r *NamespacePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	r.log.Info(fmt.Sprintf("[%s] pool status", pool.Name),
+	log.Info(fmt.Sprintf("[%s] pool status", pool.Name),
 		"ready", pool.Status.Ready,
 		"creating", pool.Status.Creating,
 		"reserved", pool.Status.Reserved)
@@ -76,14 +81,14 @@ func (r *NamespacePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	quantityOfNamespaces := r.getNamespaceQuantityDelta(pool)
 
 	if quantityOfNamespaces > 0 {
-		r.log.Info(fmt.Sprintf("filling [%s] pool with [%d] namespace(s)", pool.Name, quantityOfNamespaces))
+		log.Info(fmt.Sprintf("filling [%s] pool with [%d] namespace(s)", pool.Name, quantityOfNamespaces))
 		err := r.increaseReadyNamespacesQueue(ctx, pool, quantityOfNamespaces)
 		if err != nil {
-			r.log.Error(err, fmt.Sprintf("unable to create more namespaces for [%s] pool.", pool.Name))
+			log.Error(err, fmt.Sprintf("unable to create more namespaces for [%s] pool.", pool.Name))
 			return ctrl.Result{Requeue: true}, err
 		}
 	} else if quantityOfNamespaces < 0 {
-		r.log.Info(fmt.Sprintf("excess number of ready namespaces in [%s] pool detected, removing [%d] namespace(s)", pool.Name, (quantityOfNamespaces * -1)))
+		log.Info(fmt.Sprintf("excess number of ready namespaces in [%s] pool detected, removing [%d] namespace(s)", pool.Name, (quantityOfNamespaces * -1)))
 		err := r.decreaseReadyNamespacesQueue(ctx, pool.Name, quantityOfNamespaces)
 		if err != nil {
 			r.log.Error(err, fmt.Sprintf("unable to delete excess namespaces for [%s] pool.", pool.Name))
@@ -92,7 +97,7 @@ func (r *NamespacePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	if err := r.client.Status().Update(ctx, &pool); err != nil {
-		r.log.Error(err, fmt.Sprintf("cannot update [%s] pool status", pool.Name))
+		log.Error(err, fmt.Sprintf("cannot update [%s] pool status", pool.Name))
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/cloud.redhat.com/namespacepool_controller.go
+++ b/controllers/cloud.redhat.com/namespacepool_controller.go
@@ -38,6 +38,7 @@ import (
 // NamespacePoolReconciler reconciles a NamespacePool object
 type NamespacePoolReconciler struct {
 	client client.Client
+	ctx    context.Context
 	scheme *runtime.Scheme
 	log    logr.Logger
 }

--- a/controllers/cloud.redhat.com/namespacepool_controller.go
+++ b/controllers/cloud.redhat.com/namespacepool_controller.go
@@ -38,7 +38,6 @@ import (
 // NamespacePoolReconciler reconciles a NamespacePool object
 type NamespacePoolReconciler struct {
 	client client.Client
-	ctx    context.Context
 	scheme *runtime.Scheme
 	log    logr.Logger
 }

--- a/controllers/cloud.redhat.com/namespacereservation_controller.go
+++ b/controllers/cloud.redhat.com/namespacereservation_controller.go
@@ -62,6 +62,7 @@ type NamespaceReservationReconciler struct {
 
 func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.log.WithValues("rid", utils.RandString(5))
+	ctx = context.WithValue(ctx, helpers.ErrType("log"), &log)
 
 	// Fetch the reservation
 	res := crd.NamespaceReservation{}

--- a/controllers/cloud.redhat.com/namespacereservation_controller.go
+++ b/controllers/cloud.redhat.com/namespacereservation_controller.go
@@ -44,7 +44,6 @@ import (
 // NamespaceReservationReconciler reconciles a NamespaceReservation object
 type NamespaceReservationReconciler struct {
 	client client.Client
-	ctx    context.Context
 	scheme *runtime.Scheme
 	poller *Poller
 	log    logr.Logger

--- a/controllers/cloud.redhat.com/namespacereservation_controller.go
+++ b/controllers/cloud.redhat.com/namespacereservation_controller.go
@@ -44,6 +44,7 @@ import (
 // NamespaceReservationReconciler reconciles a NamespaceReservation object
 type NamespaceReservationReconciler struct {
 	client client.Client
+	ctx    context.Context
 	scheme *runtime.Scheme
 	poller *Poller
 	log    logr.Logger

--- a/controllers/cloud.redhat.com/namespacereservation_controller.go
+++ b/controllers/cloud.redhat.com/namespacereservation_controller.go
@@ -24,6 +24,7 @@ import (
 
 	crd "github.com/RedHatInsights/ephemeral-namespace-operator/apis/cloud.redhat.com/v1alpha1"
 	"github.com/RedHatInsights/ephemeral-namespace-operator/controllers/cloud.redhat.com/helpers"
+	"github.com/RedHatInsights/rhc-osdk-utils/utils"
 	"github.com/go-logr/logr"
 	core "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -60,6 +61,8 @@ type NamespaceReservationReconciler struct {
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings;roles,verbs=get;list;watch;create;update;patch;delete
 
 func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.log.WithValues("rid", utils.RandString(5))
+
 	// Fetch the reservation
 	res := crd.NamespaceReservation{}
 	if err := r.client.Get(ctx, req.NamespacedName, &res); err != nil {
@@ -67,7 +70,7 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 			// Must have been deleted
 			return ctrl.Result{}, nil
 		}
-		r.log.Error(err, "Reservation Not Found")
+		log.Error(err, "Reservation Not Found")
 		return ctrl.Result{}, err
 	}
 
@@ -81,7 +84,7 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 
 	switch res.Status.State {
 	case "active":
-		r.log.Info("Reconciling active reservation", "name", res.Name, "namespace", res.Status.Namespace)
+		log.Info("Reconciling active reservation", "name", res.Name, "namespace", res.Status.Namespace)
 		expirationTS, err := getExpirationTime(&res)
 		if err != nil {
 			r.log.Error(err, "Could not get expiration time for reservation", "name", res.Name)
@@ -92,7 +95,7 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 		r.poller.activeReservations[res.Name] = expirationTS
 
 		if err := r.client.Status().Update(ctx, &res); err != nil {
-			r.log.Error(err, "Cannot update reservation status", "name", res.Name)
+			log.Error(err, "Cannot update reservation status", "name", res.Name)
 			return ctrl.Result{}, err
 		}
 
@@ -101,15 +104,15 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{}, nil
 
 	case "waiting":
-		r.log.Info("Reconciling waiting reservation", "name", res.Name)
+		log.Info("Reconciling waiting reservation", "name", res.Name)
 		expirationTS, err := getExpirationTime(&res)
 		if err != nil {
-			r.log.Error(err, "Could not get expiration time for reservation", "name", res.Name)
+			log.Error(err, "Could not get expiration time for reservation", "name", res.Name)
 			return ctrl.Result{}, err
 		}
 		if r.poller.namespaceIsExpired(expirationTS) {
 			if err := r.client.Delete(ctx, &res); err != nil {
-				r.log.Error(err, "Unable to delete waiting reservation", "res-name", res.Name)
+				log.Error(err, "Unable to delete waiting reservation", "res-name", res.Name)
 			}
 			return ctrl.Result{}, nil
 		}
@@ -117,32 +120,32 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 
 	default:
 		// if no, requeue and wait for pool to populate
-		r.log.Info("Reconciling reservation", "name", res.Name)
-		r.log.Info(fmt.Sprintf("Checking %s pool for ready namespaces", res.Status.Pool), "name", res.Name)
+		log.Info("Reconciling reservation", "name", res.Name)
+		log.Info(fmt.Sprintf("Checking %s pool for ready namespaces", res.Status.Pool), "name", res.Name)
 
 		expirationTS, err := getExpirationTime(&res)
 		if err != nil {
-			r.log.Error(err, "Could not set expiration time on reservation. Deleting", "res-name", res.Name)
+			log.Error(err, "Could not set expiration time on reservation. Deleting", "res-name", res.Name)
 			if err := r.client.Delete(ctx, &res); err != nil {
-				r.log.Error(err, "cannot delete resource - aborting delete", "name", res.Name)
+				log.Error(err, "cannot delete resource - aborting delete", "name", res.Name)
 			}
 			return ctrl.Result{}, err
 		}
 
 		nsList, err := helpers.GetReadyNamespaces(ctx, r.client, res.Status.Pool)
 		if err != nil {
-			r.log.Error(err, fmt.Sprintf("unable to retrieve list of namespaces from '%s' pool", res.Status.Pool), "res-name", res.Name)
+			log.Error(err, fmt.Sprintf("unable to retrieve list of namespaces from '%s' pool", res.Status.Pool), "res-name", res.Name)
 			return ctrl.Result{}, err
 		}
 
 		if len(nsList) < 1 {
-			r.log.Info(fmt.Sprintf("requeue to wait for namespace population from '%s' pool", res.Status.Pool), "name", res.Name)
+			log.Info(fmt.Sprintf("requeue to wait for namespace population from '%s' pool", res.Status.Pool), "name", res.Name)
 			if res.Status.State == "" {
 				res.Status.State = "waiting"
 				res.Status.Expiration = expirationTS
 				err := r.client.Status().Update(ctx, &res)
 				if err != nil {
-					r.log.Error(err, "cannot update status", "name", res.Name)
+					log.Error(err, "cannot update status", "name", res.Name)
 					return ctrl.Result{}, err
 				}
 			}
@@ -151,13 +154,13 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 
 		// Check to see if there's an error with the Get
 		readyNsName := nsList[0].Name
-		r.log.Info(fmt.Sprintf("Found namespace in '%s' pool; verifying ready status", res.Status.Pool))
+		log.Info(fmt.Sprintf("Found namespace in '%s' pool; verifying ready status", res.Status.Pool))
 
 		// Verify that the ClowdEnv has been set up for the requested namespace
 		if err := r.verifyClowdEnvForReadyNs(ctx, readyNsName); err != nil {
-			r.log.Error(err, err.Error(), "namespace", readyNsName)
+			log.Error(err, err.Error(), "namespace", readyNsName)
 			if err := helpers.UpdateAnnotations(ctx, r.client, readyNsName, helpers.AnnotationEnvError.ToMap()); err != nil {
-				r.log.Error(err, fmt.Sprintf("unable to update annotations for unready namespace in '%s' pool", res.Status.Pool), "namespace", readyNsName)
+				log.Error(err, fmt.Sprintf("unable to update annotations for unready namespace in '%s' pool", res.Status.Pool), "namespace", readyNsName)
 				return ctrl.Result{Requeue: true}, err
 			}
 			return ctrl.Result{Requeue: true}, err
@@ -165,7 +168,7 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 
 		// Resolve the requested namespace and remove it from the pool
 		if err := r.reserveNamespace(ctx, readyNsName, &res); err != nil {
-			r.log.Error(err, fmt.Sprintf("could not reserve namespace from '%s' pool", res.Status.Pool), "namespace", readyNsName)
+			log.Error(err, fmt.Sprintf("could not reserve namespace from '%s' pool", res.Status.Pool), "namespace", readyNsName)
 
 			totalFailedPoolReservationsCountMetrics.With(prometheus.Labels{"pool": res.Spec.Pool}).Inc()
 
@@ -179,8 +182,8 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 
 		r.poller.activeReservations[res.Name] = expirationTS
 
-		r.log.Info("updating NamespaceReservation status")
-		r.log.Info("reservation details",
+		log.Info("updating NamespaceReservation status")
+		log.Info("reservation details",
 			"res-name", res.Name,
 			"res-uuid", res.ObjectMeta.UID,
 			"created", res.ObjectMeta.CreationTimestamp,
@@ -188,13 +191,13 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 			"status", res.Status,
 		)
 		if err := r.client.Status().Update(ctx, &res); err != nil {
-			r.log.Error(err, "cannot update status")
+			log.Error(err, "cannot update status")
 			return ctrl.Result{}, err
 		}
 
 		duration, err := parseDurationTime(*res.Spec.Duration)
 		if err != nil {
-			r.log.Error(err, "cannot parse duration")
+			log.Error(err, "cannot parse duration")
 			return ctrl.Result{}, err
 		}
 


### PR DESCRIPTION
The purpose of this PR is to add a reconciliation id to the ENO logs like Clowder has. 
![image](https://github.com/RedHatInsights/ephemeral-namespace-operator/assets/54086826/9c6b3659-e190-4c14-839b-25c1c26429bb)
