### PR TITLE
return namespace name upon failure to create the namespace

### DIFF
--- a/controllers/cloud.redhat.com/helpers/namespaces.go
+++ b/controllers/cloud.redhat.com/helpers/namespaces.go
@@ -25,13 +25,13 @@ func CreateNamespace(ctx context.Context, cl client.Client, pool *crd.NamespaceP
 
 	if pool.Spec.Local {
 		if err := cl.Create(ctx, &namespace); err != nil {
-			return "", err
+			return namespace.Name, err
 		}
 	} else {
 		project := projectv1.ProjectRequest{}
 		project.Name = namespace.Name
 		if err := cl.Create(ctx, &project); err != nil {
-			return "", err
+			return namespace.Name, err
 		}
 	}
 


### PR DESCRIPTION
Currently, if a namespace (Project) fails to be [created](https://github.com/RedHatInsights/ephemeral-namespace-operator/blob/main/controllers/cloud.redhat.com/helpers/namespaces.go#L33-L35), an empty string was returned rather than a namespace name. Since it was an empty string returned, the logic [here](https://github.com/RedHatInsights/ephemeral-namespace-operator/blob/main/controllers/cloud.redhat.com/namespacepool_controller.go#L213-L219) would never execute which added the appropriate annotation to cleanup an error namespace.