### PR TITLE
added ownerref to error namespaces for proper cleanup

### DIFF
--- a/controllers/cloud.redhat.com/helpers/namespaces.go
+++ b/controllers/cloud.redhat.com/helpers/namespaces.go
@@ -25,13 +25,13 @@ func CreateNamespace(ctx context.Context, cl client.Client, pool *crd.NamespaceP
 
 	if pool.Spec.Local {
 		if err := cl.Create(ctx, &namespace); err != nil {
-			return "", fmt.Errorf("could not create namespace [%s]: %w", namespace.Name, err)
+			return namespace.Name, fmt.Errorf("could not create namespace [%s]: %w", namespace.Name, err)
 		}
 	} else {
 		project := projectv1.ProjectRequest{}
 		project.Name = namespace.Name
 		if err := cl.Create(ctx, &project); err != nil {
-			return "", fmt.Errorf("could not create project [%s]: %w", project.Name, err)
+			return namespace.Name, fmt.Errorf("could not create project [%s]: %w", project.Name, err)
 		}
 	}
 

--- a/controllers/cloud.redhat.com/helpers/namespaces.go
+++ b/controllers/cloud.redhat.com/helpers/namespaces.go
@@ -38,7 +38,7 @@ func CreateNamespace(ctx context.Context, cl client.Client, pool *crd.NamespaceP
 	return ns.Name, nil
 }
 
-func AddNamespaceData(ctx context.Context, cl client.Client, pool *crd.NamespacePool, nsName string) (string, error) {
+func UpdateNamespaceResources(ctx context.Context, cl client.Client, pool *crd.NamespacePool, nsName string) (string, error) {
 	// WORKAROUND: Can't set annotations and ownerref on project request during create
 	// Performing annotation and ownerref change in one transaction
 	ns, err := GetNamespace(ctx, cl, nsName)

--- a/controllers/cloud.redhat.com/helpers/namespaces.go
+++ b/controllers/cloud.redhat.com/helpers/namespaces.go
@@ -39,11 +39,9 @@ func CreateNamespace(ctx context.Context, cl client.Client, pool *crd.NamespaceP
 }
 
 func UpdateNamespaceResources(ctx context.Context, cl client.Client, pool *crd.NamespacePool, nsName string) (core.Namespace, error) {
-	// WORKAROUND: Can't set annotations and ownerref on project request during create
-	// Performing annotation and ownerref change in one transaction
 	ns, err := GetNamespace(ctx, cl, nsName)
 	if err != nil {
-		return ns, fmt.Errorf("could not retrieve newly created namespace [%s]: %w", nsName, err)
+		return ns, fmt.Errorf("could not retrieve namespace [%s]: %w", nsName, err)
 	}
 
 	utils.UpdateAnnotations(&ns, CreateInitialAnnotations())

--- a/controllers/cloud.redhat.com/helpers/namespaces.go
+++ b/controllers/cloud.redhat.com/helpers/namespaces.go
@@ -157,28 +157,6 @@ func UpdateAnnotations(ctx context.Context, cl client.Client, namespaceName stri
 	return nil
 }
 
-func UpdateLabels(ctx context.Context, cl client.Client, namespaceName string, annotations map[string]string) error {
-	namespace, err := GetNamespace(ctx, cl, namespaceName)
-	if err != nil {
-		return fmt.Errorf("error updating labels for namespace [%s]: %w", namespaceName, err)
-	}
-
-	utils.UpdateLabels(&namespace, annotations)
-
-	err = retry.RetryOnConflict(
-		retry.DefaultBackoff,
-		func() error {
-			if err = cl.Update(ctx, &namespace); err != nil {
-				return fmt.Errorf("there was an issue updating labels for namespace [%s]: %w", namespaceName, err)
-			}
-
-			return nil
-		},
-	)
-
-	return nil
-}
-
 func CopySecrets(ctx context.Context, cl client.Client, namespaceName string) error {
 	secrets := core.SecretList{}
 	if err := cl.List(ctx, &secrets, client.InNamespace(NamespaceEphemeralBase)); err != nil {

--- a/controllers/cloud.redhat.com/namespacepool_controller.go
+++ b/controllers/cloud.redhat.com/namespacepool_controller.go
@@ -208,7 +208,7 @@ func (r *NamespacePoolReconciler) increaseReadyNamespacesQueue(ctx context.Conte
 			r.log.Error(err, "namespace/project creation failed for [%s]", namespaceName)
 		}
 
-		namespaceName, err = helpers.AddNamespaceData(ctx, r.client, &pool, namespaceName)
+		namespaceName, err = helpers.UpdateNamespaceResources(ctx, r.client, &pool, namespaceName)
 		if err == nil {
 			r.log.Info(fmt.Sprintf("successfully created namespace [%s] in [%s] pool", namespaceName, pool.Name))
 			continue

--- a/controllers/cloud.redhat.com/namespacepool_controller.go
+++ b/controllers/cloud.redhat.com/namespacepool_controller.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-logr/logr"
 	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -211,6 +212,15 @@ func (r *NamespacePoolReconciler) increaseReadyNamespacesQueue(ctx context.Conte
 
 		r.log.Error(err, fmt.Sprintf("error while creating namespace [%s]", namespaceName))
 		if namespaceName != "" {
+			namespace := core.Namespace{}
+
+			err := r.client.Get(ctx, types.NamespacedName{Name: namespaceName}, &namespace)
+				return fmt.Errorf(fmt.Sprintf("cannot retrieve error namespace [%s] to update ownerreference", namespaceName))
+			}
+
+			// proper cleanup of error namespaces involves adding the ownerreference to these namespaces
+			namespace.SetOwnerReferences([]metav1.OwnerReference{pool.MakeOwnerReference()})
+			
 			err := helpers.UpdateAnnotations(ctx, r.client, namespaceName, helpers.AnnotationEnvError.ToMap())
 			if err != nil {
 				r.log.Error(err, "error while updating annotations on namespace", "namespace", namespaceName)

--- a/controllers/cloud.redhat.com/namespacepool_controller.go
+++ b/controllers/cloud.redhat.com/namespacepool_controller.go
@@ -218,12 +218,6 @@ func (r *NamespacePoolReconciler) increaseReadyNamespacesQueue(ctx context.Conte
 		if err := r.client.Delete(ctx, &ns); err != nil {
 			return fmt.Errorf(fmt.Sprintf("cannot delete error namespace [%s]", nsName))
 		}
-
-		err = helpers.UpdateAnnotations(ctx, r.client, nsName, helpers.AnnotationEnvError.ToMap())
-		if err != nil {
-			r.log.Error(err, "error while updating annotations on namespace", "namespace", nsName)
-			return err
-		}
 	}
 
 	return nil

--- a/controllers/cloud.redhat.com/namespacepool_controller.go
+++ b/controllers/cloud.redhat.com/namespacepool_controller.go
@@ -214,7 +214,7 @@ func (r *NamespacePoolReconciler) increaseReadyNamespacesQueue(ctx context.Conte
 			continue
 		}
 
-		r.log.Error(err, fmt.Sprintf("error while creating namespace [%s]", nsName))
+		r.log.Error(err, fmt.Sprintf("error while updating namespace resources for [%s]", nsName))
 		if err := r.client.Delete(ctx, &ns); err != nil {
 			return fmt.Errorf(fmt.Sprintf("cannot delete error namespace [%s]", nsName))
 		}


### PR DESCRIPTION
If namespace creation fails - which according to the pod logs occurs [here](https://github.com/RedHatInsights/ephemeral-namespace-operator/blob/main/controllers/cloud.redhat.com/helpers/namespaces.go#L50) -  let's just remove that namespace immediately. 

An alternative solution is to mess with logic [here](https://github.com/RedHatInsights/ephemeral-namespace-operator/blob/main/controllers/cloud.redhat.com/namespacepool_controller.go#L159) to change the check on whether the namespace has the correct ownerreference. Due to where the failure occurs, the ownerreference is never added to the namespace which is why it doesn't get added to the list of error namespaces to be cleaned up.

Plus some refactoring of the create namespace function :smile: 