### PR TITLE
remove log error message stating hostname not populated

### DIFF
--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -65,8 +65,8 @@ func (r *ClowdenvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		"deployments", fmt.Sprintf("%d / %d", env.Status.Deployments.ReadyDeployments, env.Status.Deployments.ManagedDeployments),
 	)
 
-	if ready, err := helpers.VerifyClowdEnvReady(env); !ready {
-		return ctrl.Result{Requeue: true}, err
+	if ready := helpers.VerifyClowdEnvReady(env); !ready {
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	namespaceName := env.Spec.TargetNamespace

--- a/controllers/cloud.redhat.com/helpers/clowdenvs.go
+++ b/controllers/cloud.redhat.com/helpers/clowdenvs.go
@@ -58,10 +58,10 @@ func GetClowdEnv(ctx context.Context, cl client.Client, namespaceName string) (b
 	return ready, &env, nil
 }
 
-func VerifyClowdEnvReady(env clowder.ClowdEnvironment) (bool, error) {
+func VerifyClowdEnvReady(env clowder.ClowdEnvironment) bool {
 	// check that hostname is populated if ClowdEnvironment is operating in 'local' web mode
 	if env.Spec.Providers.Web.Mode == "local" && env.Status.Hostname == "" {
-		return false, fmt.Errorf("hostname not populated for clowdenvironment [%s]", env.Name)
+		return false
 	}
 
 	conditions := env.Status.Conditions
@@ -78,5 +78,5 @@ func VerifyClowdEnvReady(env clowder.ClowdEnvironment) (bool, error) {
 		}
 	}
 
-	return (reconciliationSuccessful && deploymentsReady), nil
+	return (reconciliationSuccessful && deploymentsReady)
 }

--- a/controllers/cloud.redhat.com/helpers/clowdenvs.go
+++ b/controllers/cloud.redhat.com/helpers/clowdenvs.go
@@ -50,9 +50,9 @@ func GetClowdEnv(ctx context.Context, cl client.Client, namespaceName string) (b
 		return false, nil, fmt.Errorf("could not retrieve clowdenvironment [%s]: %w", env.Name, err)
 	}
 
-	ready, err := VerifyClowdEnvReady(env)
-	if err != nil {
-		return ready, &env, fmt.Errorf("could not verify that the clowdenvironment [%s] was ready: %w", env.Name, err)
+	ready := VerifyClowdEnvReady(env)
+	if !ready {
+		return ready, &env, nil
 	}
 
 	return ready, &env, nil


### PR DESCRIPTION
Log messages spam an error `hostname not populated for clowdenvironment ...` while waiting for data to be populated. Since this is just a simple check that data has been set, we will just return `true` or `false` to denote its ready status. 