### PR TITLE
adding more unit tests

### DIFF
--- a/controllers/cloud.redhat.com/clowdenvironment_controller_suite_test.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller_suite_test.go
@@ -2,11 +2,20 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	clowder "github.com/RedHatInsights/clowder/apis/cloud.redhat.com/v1alpha1"
+	crd "github.com/RedHatInsights/ephemeral-namespace-operator/apis/cloud.redhat.com/v1alpha1"
+	"github.com/RedHatInsights/ephemeral-namespace-operator/controllers/cloud.redhat.com/helpers"
+	frontend "github.com/RedHatInsights/frontend-operator/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	core "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 var _ = Describe("Clowdenvironment controller basic update", func() {
@@ -59,6 +68,579 @@ var _ = Describe("Clowdenvironment controller basic update", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(isOwnedByPool(ctx, k8sClient, ns.Name)).To(Equal(false))
+		})
+
+		It("Should handle ClowdEnvironment status transitions properly", func() {
+			ctx := context.Background()
+
+			By("Creating a test namespace with pool ownership")
+			testNs := &core.Namespace{}
+			testNs.Name = "test-clowdenv-ns"
+			testNs.Labels = map[string]string{
+				"operator-ns": "true",
+				"pool":        "default",
+			}
+
+			// Create mock pool for ownership
+			pool := &crd.NamespacePool{}
+			pool.Name = "test-pool"
+			pool.Namespace = "default"
+			err := k8sClient.Create(ctx, pool)
+			if err != nil && !k8serr.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			testNs.OwnerReferences = []metav1.OwnerReference{
+				{
+					APIVersion: "cloud.redhat.com/v1alpha1",
+					Kind:       "NamespacePool",
+					Name:       pool.Name,
+					UID:        pool.UID,
+					Controller: &[]bool{true}[0],
+				},
+			}
+
+			err = k8sClient.Create(ctx, testNs)
+			if err != nil && !k8serr.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("Creating a ClowdEnvironment in the test namespace")
+			clowdEnv := &clowder.ClowdEnvironment{}
+			clowdEnv.Name = "test-env"
+			clowdEnv.Namespace = "default"
+			clowdEnv.Spec.TargetNamespace = testNs.Name
+			clowdEnv.Status.Deployments.ManagedDeployments = 1
+			clowdEnv.Status.Deployments.ReadyDeployments = 1
+
+			err = k8sClient.Create(ctx, clowdEnv)
+			if err != nil && !k8serr.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("Verifying namespace annotations are updated")
+			Eventually(func() string {
+				updatedNs := &core.Namespace{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: testNs.Name}, updatedNs)
+				if err != nil {
+					return ""
+				}
+				return updatedNs.Annotations["env-status"]
+			}, timeout, interval).Should(Or(Equal("ready"), Equal("creating")))
+		})
+
+		It("Should handle ClowdEnvironment with unready deployments", func() {
+			ctx := context.Background()
+
+			By("Creating ClowdEnvironment with unready deployments")
+			testNs := &core.Namespace{}
+			testNs.Name = "test-unready-clowdenv"
+			testNs.Labels = map[string]string{
+				"operator-ns": "true",
+				"pool":        "default",
+			}
+
+			err := k8sClient.Create(ctx, testNs)
+			if err != nil && !k8serr.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			clowdEnv := &clowder.ClowdEnvironment{}
+			clowdEnv.Name = "test-unready-env"
+			clowdEnv.Namespace = "default"
+			clowdEnv.Spec.TargetNamespace = testNs.Name
+			clowdEnv.Status.Deployments.ManagedDeployments = 3
+			clowdEnv.Status.Deployments.ReadyDeployments = 1 // Not all ready
+
+			err = k8sClient.Create(ctx, clowdEnv)
+			if err != nil && !k8serr.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("Verifying namespace does not get marked as ready")
+			Consistently(func() string {
+				updatedNs := &core.Namespace{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: testNs.Name}, updatedNs)
+				if err != nil {
+					return ""
+				}
+				if status, ok := updatedNs.Annotations["env-status"]; ok {
+					return status
+				}
+				return "unknown"
+			}, time.Second*5, time.Millisecond*500).ShouldNot(Equal("ready"))
+		})
+
+		It("Should create FrontendEnvironment when ClowdEnvironment is ready", func() {
+			ctx := context.Background()
+
+			By("Creating a ready ClowdEnvironment")
+			testNs := &core.Namespace{}
+			testNs.Name = "test-frontend-ns"
+			testNs.Labels = map[string]string{
+				"operator-ns": "true",
+				"pool":        "default",
+			}
+
+			err := k8sClient.Create(ctx, testNs)
+			if err != nil && !k8serr.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			clowdEnv := &clowder.ClowdEnvironment{}
+			clowdEnv.Name = "test-frontend-env"
+			clowdEnv.Namespace = "default"
+			clowdEnv.Spec.TargetNamespace = testNs.Name
+			clowdEnv.Status.Deployments.ManagedDeployments = 1
+			clowdEnv.Status.Deployments.ReadyDeployments = 1
+
+			err = k8sClient.Create(ctx, clowdEnv)
+			if err != nil && !k8serr.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("Verifying FrontendEnvironment is created")
+			Eventually(func() bool {
+				frontendEnv := &frontend.FrontendEnvironment{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      testNs.Name,
+					Namespace: testNs.Name,
+				}, frontendEnv)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("Should handle error conditions in ClowdEnvironment processing", func() {
+			ctx := context.Background()
+
+			By("Creating a ClowdEnvironment that will cause processing errors")
+			testNs := &core.Namespace{}
+			testNs.Name = "test-error-ns"
+			testNs.Labels = map[string]string{
+				"operator-ns": "true",
+				"pool":        "default",
+			}
+
+			err := k8sClient.Create(ctx, testNs)
+			if err != nil && !k8serr.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			clowdEnv := &clowder.ClowdEnvironment{}
+			clowdEnv.Name = "test-error-env"
+			clowdEnv.Namespace = "default"
+			clowdEnv.Spec.TargetNamespace = testNs.Name
+			clowdEnv.Status.Deployments.ManagedDeployments = 1
+			clowdEnv.Status.Deployments.ReadyDeployments = 1
+
+			err = k8sClient.Create(ctx, clowdEnv)
+			if err != nil && !k8serr.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("Simulating an error by setting invalid annotations")
+			err = helpers.UpdateAnnotations(ctx, k8sClient, testNs.Name, helpers.AnnotationEnvError.ToMap())
+			if err == nil {
+				By("Verifying error annotation is set")
+				Eventually(func() string {
+					updatedNs := &core.Namespace{}
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: testNs.Name}, updatedNs)
+					if err != nil {
+						return ""
+					}
+					return updatedNs.Annotations["env-status"]
+				}, timeout, interval).Should(Equal("error"))
+			}
+		})
+	})
+
+	Context("When handling ClowdEnvironment edge cases", func() {
+		It("Should handle missing target namespace gracefully", func() {
+			ctx := context.Background()
+
+			By("Creating ClowdEnvironment with non-existent target namespace")
+			clowdEnv := &clowder.ClowdEnvironment{}
+			clowdEnv.Name = "test-missing-target"
+			clowdEnv.Namespace = "default"
+			clowdEnv.Spec.TargetNamespace = "non-existent-namespace"
+			clowdEnv.Status.Deployments.ManagedDeployments = 1
+			clowdEnv.Status.Deployments.ReadyDeployments = 1
+
+			err := k8sClient.Create(ctx, clowdEnv)
+			if err != nil && !k8serr.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("Verifying controller handles missing target namespace")
+			// The controller should not crash and should handle this gracefully
+			Eventually(func() bool {
+				return true // Just verify the controller is still running
+			}, time.Second*5, time.Millisecond*500).Should(BeTrue())
+		})
+
+		It("Should handle ClowdEnvironment deletion", func() {
+			ctx := context.Background()
+
+			By("Creating and then deleting a ClowdEnvironment")
+			testNs := &core.Namespace{}
+			testNs.Name = "test-delete-ns"
+			testNs.Labels = map[string]string{
+				"operator-ns": "true",
+				"pool":        "default",
+			}
+
+			err := k8sClient.Create(ctx, testNs)
+			if err != nil && !k8serr.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			clowdEnv := &clowder.ClowdEnvironment{}
+			clowdEnv.Name = "test-delete-env"
+			clowdEnv.Namespace = "default"
+			clowdEnv.Spec.TargetNamespace = testNs.Name
+			clowdEnv.Status.Deployments.ManagedDeployments = 1
+			clowdEnv.Status.Deployments.ReadyDeployments = 1
+
+			err = k8sClient.Create(ctx, clowdEnv)
+			if err != nil && !k8serr.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("Deleting the ClowdEnvironment")
+			err = k8sClient.Delete(ctx, clowdEnv)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying ClowdEnvironment is deleted")
+			Eventually(func() bool {
+				deletedEnv := &clowder.ClowdEnvironment{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      clowdEnv.Name,
+					Namespace: clowdEnv.Namespace,
+				}, deletedEnv)
+				return k8serr.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("Should handle multiple ClowdEnvironments in different namespaces", func() {
+			ctx := context.Background()
+
+			namespaces := []string{"test-multi-1", "test-multi-2", "test-multi-3"}
+
+			By("Creating multiple namespaces with ClowdEnvironments")
+			for i, nsName := range namespaces {
+				testNs := &core.Namespace{}
+				testNs.Name = nsName
+				testNs.Labels = map[string]string{
+					"operator-ns": "true",
+					"pool":        "default",
+				}
+
+				err := k8sClient.Create(ctx, testNs)
+				if err != nil && !k8serr.IsAlreadyExists(err) {
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				clowdEnv := &clowder.ClowdEnvironment{}
+				clowdEnv.Name = fmt.Sprintf("test-multi-env-%d", i)
+				clowdEnv.Namespace = "default"
+				clowdEnv.Spec.TargetNamespace = nsName
+				clowdEnv.Status.Deployments.ManagedDeployments = 1
+				clowdEnv.Status.Deployments.ReadyDeployments = 1
+
+				err = k8sClient.Create(ctx, clowdEnv)
+				if err != nil && !k8serr.IsAlreadyExists(err) {
+					Expect(err).NotTo(HaveOccurred())
+				}
+			}
+
+			By("Verifying all namespaces are processed correctly")
+			for _, nsName := range namespaces {
+				Eventually(func() bool {
+					ns := &core.Namespace{}
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: nsName}, ns)
+					if err != nil {
+						return false
+					}
+					return ns.Annotations["env-status"] == "ready" || ns.Annotations["env-status"] == "creating"
+				}, timeout, interval).Should(BeTrue())
+			}
+		})
+
+		It("Should handle concurrent ClowdEnvironment updates", func() {
+			ctx := context.Background()
+
+			By("Creating a ClowdEnvironment")
+			testNs := &core.Namespace{}
+			testNs.Name = "test-concurrent-ns"
+			testNs.Labels = map[string]string{
+				"operator-ns": "true",
+				"pool":        "default",
+			}
+
+			err := k8sClient.Create(ctx, testNs)
+			if err != nil && !k8serr.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			clowdEnv := &clowder.ClowdEnvironment{}
+			clowdEnv.Name = "test-concurrent-env"
+			clowdEnv.Namespace = "default"
+			clowdEnv.Spec.TargetNamespace = testNs.Name
+			clowdEnv.Status.Deployments.ManagedDeployments = 2
+			clowdEnv.Status.Deployments.ReadyDeployments = 1
+
+			err = k8sClient.Create(ctx, clowdEnv)
+			if err != nil && !k8serr.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("Updating ClowdEnvironment to ready state")
+			Eventually(func() error {
+				updatedEnv := &clowder.ClowdEnvironment{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      clowdEnv.Name,
+					Namespace: clowdEnv.Namespace,
+				}, updatedEnv)
+				if err != nil {
+					return err
+				}
+
+				updatedEnv.Status.Deployments.ReadyDeployments = 2
+				return k8sClient.Status().Update(ctx, updatedEnv)
+			}, timeout, interval).Should(Succeed())
+
+			By("Verifying namespace status is eventually updated")
+			Eventually(func() string {
+				ns := &core.Namespace{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: testNs.Name}, ns)
+				if err != nil {
+					return ""
+				}
+				return ns.Annotations["env-status"]
+			}, timeout, interval).Should(Equal("ready"))
+		})
+	})
+
+	Context("When testing ClowdEnvironment readiness verification", func() {
+		It("Should properly evaluate readiness conditions", func() {
+			By("Testing ClowdEnvironment readiness with different condition states")
+
+			// Test case 1: Environment with proper conditions
+			readyEnv := clowder.ClowdEnvironment{
+				Spec: clowder.ClowdEnvironmentSpec{
+					Providers: clowder.ProvidersConfig{
+						Web: clowder.WebConfig{
+							Mode: "operator",
+						},
+					},
+				},
+				Status: clowder.ClowdEnvironmentStatus{
+					Conditions: []clusterv1.Condition{
+						{
+							Type:   clowder.ReconciliationSuccessful,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:   clowder.DeploymentsReady,
+							Status: core.ConditionTrue,
+						},
+					},
+				},
+			}
+			Expect(helpers.VerifyClowdEnvReady(readyEnv)).To(BeTrue())
+
+			// Test case 2: Environment with missing conditions
+			notReadyEnv := clowder.ClowdEnvironment{
+				Spec: clowder.ClowdEnvironmentSpec{
+					Providers: clowder.ProvidersConfig{
+						Web: clowder.WebConfig{
+							Mode: "operator",
+						},
+					},
+				},
+				Status: clowder.ClowdEnvironmentStatus{
+					Conditions: []clusterv1.Condition{
+						{
+							Type:   clowder.ReconciliationSuccessful,
+							Status: core.ConditionTrue,
+						},
+					},
+				},
+			}
+			Expect(helpers.VerifyClowdEnvReady(notReadyEnv)).To(BeFalse())
+
+			// Test case 3: Environment in local mode without hostname
+			localEnv := clowder.ClowdEnvironment{
+				Spec: clowder.ClowdEnvironmentSpec{
+					Providers: clowder.ProvidersConfig{
+						Web: clowder.WebConfig{
+							Mode: "local",
+						},
+					},
+				},
+				Status: clowder.ClowdEnvironmentStatus{
+					Hostname: "", // Missing hostname for local mode
+					Conditions: []clusterv1.Condition{
+						{
+							Type:   clowder.ReconciliationSuccessful,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:   clowder.DeploymentsReady,
+							Status: core.ConditionTrue,
+						},
+					},
+				},
+			}
+			Expect(helpers.VerifyClowdEnvReady(localEnv)).To(BeFalse())
+
+			// Test case 4: Environment in local mode with hostname
+			localReadyEnv := clowder.ClowdEnvironment{
+				Spec: clowder.ClowdEnvironmentSpec{
+					Providers: clowder.ProvidersConfig{
+						Web: clowder.WebConfig{
+							Mode: "local",
+						},
+					},
+				},
+				Status: clowder.ClowdEnvironmentStatus{
+					Hostname: "test.example.com",
+					Conditions: []clusterv1.Condition{
+						{
+							Type:   clowder.ReconciliationSuccessful,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:   clowder.DeploymentsReady,
+							Status: core.ConditionTrue,
+						},
+					},
+				},
+			}
+			Expect(helpers.VerifyClowdEnvReady(localReadyEnv)).To(BeTrue())
+		})
+
+		It("Should handle edge cases in condition states", func() {
+			By("Testing with empty conditions")
+
+			emptyEnv := clowder.ClowdEnvironment{
+				Spec: clowder.ClowdEnvironmentSpec{
+					Providers: clowder.ProvidersConfig{
+						Web: clowder.WebConfig{
+							Mode: "operator",
+						},
+					},
+				},
+				Status: clowder.ClowdEnvironmentStatus{
+					Conditions: []clusterv1.Condition{},
+				},
+			}
+			Expect(helpers.VerifyClowdEnvReady(emptyEnv)).To(BeFalse())
+
+			By("Testing with false conditions")
+			falseEnv := clowder.ClowdEnvironment{
+				Spec: clowder.ClowdEnvironmentSpec{
+					Providers: clowder.ProvidersConfig{
+						Web: clowder.WebConfig{
+							Mode: "operator",
+						},
+					},
+				},
+				Status: clowder.ClowdEnvironmentStatus{
+					Conditions: []clusterv1.Condition{
+						{
+							Type:   clowder.ReconciliationSuccessful,
+							Status: core.ConditionFalse,
+						},
+						{
+							Type:   clowder.DeploymentsReady,
+							Status: core.ConditionFalse,
+						},
+					},
+				},
+			}
+			Expect(helpers.VerifyClowdEnvReady(falseEnv)).To(BeFalse())
+		})
+	})
+
+	Context("When testing annotation handling", func() {
+		It("Should properly update completion time annotations", func() {
+			ctx := context.Background()
+
+			By("Creating a namespace for completion time testing")
+			testNs := &core.Namespace{}
+			testNs.Name = "test-completion-time"
+			testNs.Labels = map[string]string{
+				"operator-ns": "true",
+				"pool":        "default",
+			}
+
+			err := k8sClient.Create(ctx, testNs)
+			if err != nil && !k8serr.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("Setting ready annotation")
+			err = helpers.UpdateAnnotations(ctx, k8sClient, testNs.Name, helpers.AnnotationEnvReady.ToMap())
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying annotation is set")
+			Eventually(func() string {
+				updatedNs := &core.Namespace{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: testNs.Name}, updatedNs)
+				if err != nil {
+					return ""
+				}
+				return updatedNs.Annotations["env-status"]
+			}, timeout, interval).Should(Equal("ready"))
+		})
+
+		It("Should handle annotation update errors gracefully", func() {
+			ctx := context.Background()
+
+			By("Attempting to update annotations on non-existent namespace")
+			err := helpers.UpdateAnnotations(ctx, k8sClient, "non-existent-namespace", helpers.AnnotationEnvReady.ToMap())
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should handle various annotation states", func() {
+			ctx := context.Background()
+
+			testStates := []helpers.CustomAnnotation{
+				helpers.AnnotationEnvCreating,
+				helpers.AnnotationEnvReady,
+				helpers.AnnotationEnvError,
+				helpers.AnnotationEnvDeleting,
+			}
+
+			for i, state := range testStates {
+				nsName := fmt.Sprintf("test-annotation-state-%d", i)
+				testNs := &core.Namespace{}
+				testNs.Name = nsName
+				testNs.Labels = map[string]string{
+					"operator-ns": "true",
+					"pool":        "default",
+				}
+
+				err := k8sClient.Create(ctx, testNs)
+				if err != nil && !k8serr.IsAlreadyExists(err) {
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				By(fmt.Sprintf("Setting %s annotation", state.Value))
+				err = helpers.UpdateAnnotations(ctx, k8sClient, nsName, state.ToMap())
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying annotation is set correctly")
+				Eventually(func() string {
+					updatedNs := &core.Namespace{}
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: nsName}, updatedNs)
+					if err != nil {
+						return ""
+					}
+					return updatedNs.Annotations["env-status"]
+				}, timeout, interval).Should(Equal(state.Value))
+			}
 		})
 	})
 })

--- a/controllers/cloud.redhat.com/namespacereservation_controller_suite_test.go
+++ b/controllers/cloud.redhat.com/namespacereservation_controller_suite_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	core "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -132,6 +133,61 @@ var _ = Describe("Reservation controller basic reservation", func() {
 				return pool.Spec.Size == pool.Status.Ready
 			}, timeout, interval).Should(BeTrue())
 		})
+
+		It("Should properly set reservation status fields", func() {
+			ctx := context.Background()
+			resName := "test-status-fields"
+
+			reservation := helpers.NewReservation(resName, "1h", "test-user-status", "default")
+			Expect(k8sClient.Create(ctx, reservation)).Should(Succeed())
+
+			updatedReservation := &crd.NamespaceReservation{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, updatedReservation)
+				if err != nil {
+					return false
+				}
+
+				By("Verifying all status fields are properly set")
+				hasState := updatedReservation.Status.State != ""
+				hasPool := updatedReservation.Status.Pool != ""
+				hasNamespace := updatedReservation.Status.Namespace != ""
+				hasExpiration := !updatedReservation.Status.Expiration.IsZero()
+
+				return hasState && hasPool && hasNamespace && hasExpiration
+			}, timeout, interval).Should(BeTrue())
+
+			By("Verifying status field values are correct")
+			Expect(updatedReservation.Status.State).To(Equal("active"))
+			Expect(updatedReservation.Status.Pool).To(Equal("default"))
+			Expect(updatedReservation.Status.Namespace).NotTo(BeEmpty())
+			Expect(updatedReservation.Status.Expiration.Time).To(BeTemporally(">", time.Now()))
+		})
+
+		It("Should handle reservation state transitions properly", func() {
+			ctx := context.Background()
+			resName := "test-state-transition"
+
+			reservation := helpers.NewReservation(resName, "30m", "test-user-transition", "default")
+			Expect(k8sClient.Create(ctx, reservation)).Should(Succeed())
+
+			updatedReservation := &crd.NamespaceReservation{}
+
+			By("Initially reservation should be in pending or active state")
+			Eventually(func() string {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, updatedReservation)
+				if err != nil {
+					return ""
+				}
+				return updatedReservation.Status.State
+			}, timeout, interval).Should(Or(Equal("active"), Equal("pending")))
+
+			By("Active reservations should have assigned namespaces")
+			if updatedReservation.Status.State == "active" {
+				Expect(updatedReservation.Status.Namespace).NotTo(BeEmpty())
+			}
+		})
 	})
 })
 
@@ -166,6 +222,52 @@ var _ = Describe("Handle reservation without defined pool type", func() {
 				return pool.Spec.Size == pool.Status.Ready
 			}, timeout, interval).Should(BeTrue())
 		})
+
+		It("Should handle empty pool spec gracefully", func() {
+			ctx := context.Background()
+			resName := "test-empty-pool"
+			reservation := helpers.NewReservation(resName, "1h", "test-user-empty", "")
+
+			Expect(k8sClient.Create(ctx, reservation)).Should(Succeed())
+			updatedReservation := &crd.NamespaceReservation{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, updatedReservation)
+				if err != nil {
+					return false
+				}
+				return updatedReservation.Status.Pool == "default"
+			}, timeout, interval).Should(BeTrue())
+
+			By("Verifying reservation becomes active with default pool")
+			Eventually(func() string {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, updatedReservation)
+				if err != nil {
+					return ""
+				}
+				return updatedReservation.Status.State
+			}, timeout, interval).Should(Equal("active"))
+		})
+
+		It("Should handle non-existent pool names", func() {
+			ctx := context.Background()
+			resName := "test-invalid-pool"
+			reservation := helpers.NewReservation(resName, "1h", "test-user-invalid", "non-existent-pool")
+
+			By("Creating reservation with non-existent pool")
+			Expect(k8sClient.Create(ctx, reservation)).Should(Succeed())
+
+			updatedReservation := &crd.NamespaceReservation{}
+
+			By("Reservation should still be created but may be in waiting state")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, updatedReservation)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("Pool should be set to the specified value even if non-existent")
+			Expect(updatedReservation.Status.Pool).To(Equal("non-existent-pool"))
+		})
 	})
 })
 
@@ -188,6 +290,70 @@ var _ = Describe("Handle reservation without duration specified", func() {
 
 				return duration.String() == "1h0m0s"
 			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("Should handle various duration formats", func() {
+			ctx := context.Background()
+
+			testCases := []struct {
+				name           string
+				duration       string
+				expectedResult string
+			}{
+				{"minutes", "30m", "30m0s"},
+				{"hours", "2h", "2h0m0s"},
+				{"mixed", "1h30m", "1h30m0s"},
+				{"seconds", "45s", "45s"},
+				{"complex", "2h15m30s", "2h15m30s"},
+			}
+
+			for _, tc := range testCases {
+				resName := fmt.Sprintf("test-duration-%s", tc.name)
+				reservation := helpers.NewReservation(resName, tc.duration, fmt.Sprintf("test-user-%s", tc.name), "default")
+
+				Expect(k8sClient.Create(ctx, reservation)).Should(Succeed())
+				updatedReservation := &crd.NamespaceReservation{}
+
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, updatedReservation)
+					if err != nil {
+						return false
+					}
+
+					if updatedReservation.Spec.Duration == nil {
+						return false
+					}
+
+					duration, err := parseDurationTime(*updatedReservation.Spec.Duration)
+					return err == nil && duration.String() == tc.expectedResult
+				}, timeout, interval).Should(BeTrue())
+			}
+		})
+
+		It("Should handle invalid duration formats gracefully", func() {
+			ctx := context.Background()
+			resName := "test-invalid-duration"
+			reservation := helpers.NewReservation(resName, "invalid-duration", "test-user-invalid", "default")
+
+			By("Creating reservation with invalid duration")
+			err := k8sClient.Create(ctx, reservation)
+			// Note: The creation itself might succeed, but the controller should handle the error
+			if err == nil {
+				updatedReservation := &crd.NamespaceReservation{}
+
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, updatedReservation)
+					return err == nil
+				}, timeout, interval).Should(BeTrue())
+
+				By("Default duration should be applied for invalid formats")
+				if updatedReservation.Spec.Duration != nil {
+					duration, err := parseDurationTime(*updatedReservation.Spec.Duration)
+					if err == nil {
+						Expect(duration.String()).To(Equal("1h0m0s"))
+					}
+				}
+			}
 		})
 	})
 })
@@ -224,6 +390,364 @@ var _ = Describe("Handle waiting reservations", func() {
 				return updatedRes5.Status.State == "waiting"
 			}, timeout, interval).Should(BeTrue())
 
+		})
+
+		It("Should transition waiting reservations to active when namespaces become available", func() {
+			ctx := context.Background()
+
+			By("Creating reservations that will cause some to wait")
+			resNames := []string{"wait-test-1", "wait-test-2", "wait-test-3", "wait-test-4"}
+			reservations := make([]*crd.NamespaceReservation, len(resNames))
+
+			for i, resName := range resNames {
+				res := helpers.NewReservation(resName, "30m", fmt.Sprintf("wait-user-%d", i), "minimal")
+				Expect(k8sClient.Create(ctx, res)).Should(Succeed())
+				reservations[i] = res
+			}
+
+			By("Verifying some reservations are in waiting state")
+			Eventually(func() int {
+				waitingCount := 0
+				for _, resName := range resNames {
+					res := &crd.NamespaceReservation{}
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, res)
+					if err == nil && res.Status.State == "waiting" {
+						waitingCount++
+					}
+				}
+				return waitingCount
+			}, timeout, interval).Should(BeNumerically(">", 0))
+
+			By("Deleting an active reservation to free up a namespace")
+			for _, resName := range resNames {
+				res := &crd.NamespaceReservation{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, res)
+				if err == nil && res.Status.State == "active" {
+					Expect(k8sClient.Delete(ctx, res)).Should(Succeed())
+					break
+				}
+			}
+
+			By("Verifying waiting reservations transition to active")
+			Eventually(func() int {
+				activeCount := 0
+				for _, resName := range resNames {
+					res := &crd.NamespaceReservation{}
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, res)
+					if err == nil && res.Status.State == "active" {
+						activeCount++
+					}
+				}
+				return activeCount
+			}, timeout, interval).Should(BeNumerically(">", 0))
+		})
+
+		It("Should maintain FIFO order for waiting reservations", func() {
+			ctx := context.Background()
+
+			By("Creating multiple reservations in sequence")
+			resNames := []string{"fifo-1", "fifo-2", "fifo-3"}
+			creationTimes := make(map[string]metav1.Time)
+
+			for i, resName := range resNames {
+				res := helpers.NewReservation(resName, "1h", fmt.Sprintf("fifo-user-%d", i), "minimal")
+				Expect(k8sClient.Create(ctx, res)).Should(Succeed())
+
+				// Record creation time
+				Eventually(func() bool {
+					updatedRes := &crd.NamespaceReservation{}
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, updatedRes)
+					if err == nil {
+						creationTimes[resName] = updatedRes.CreationTimestamp
+						return true
+					}
+					return false
+				}, timeout, interval).Should(BeTrue())
+
+				// Small delay to ensure different creation times
+				time.Sleep(time.Millisecond * 100)
+			}
+
+			By("Verifying creation timestamps are in order")
+			for i := 1; i < len(resNames); i++ {
+				prevTime := creationTimes[resNames[i-1]]
+				currTime := creationTimes[resNames[i]]
+				Expect(currTime.Time).To(BeTemporally(">=", prevTime.Time))
+			}
+		})
+	})
+})
+
+var _ = Describe("Reservation expiration and cleanup", func() {
+	Context("When reservations expire", func() {
+		It("Should handle very short expiration times", func() {
+			ctx := context.Background()
+			resName := "test-quick-expire"
+
+			reservation := helpers.NewReservation(resName, "2s", "test-user-quick", "default")
+			Expect(k8sClient.Create(ctx, reservation)).Should(Succeed())
+
+			By("Verifying reservation is deleted after expiration")
+			Eventually(func() bool {
+				res := &crd.NamespaceReservation{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, res)
+				return k8serr.IsNotFound(err)
+			}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+		})
+
+		It("Should clean up associated namespace when reservation expires", func() {
+			ctx := context.Background()
+			resName := "test-namespace-cleanup"
+
+			reservation := helpers.NewReservation(resName, "3s", "test-user-cleanup", "default")
+			Expect(k8sClient.Create(ctx, reservation)).Should(Succeed())
+
+			var namespaceName string
+			updatedReservation := &crd.NamespaceReservation{}
+
+			By("Getting assigned namespace name")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, updatedReservation)
+				if err == nil && updatedReservation.Status.State == "active" {
+					namespaceName = updatedReservation.Status.Namespace
+					return namespaceName != ""
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Waiting for reservation to expire")
+			Eventually(func() bool {
+				res := &crd.NamespaceReservation{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, res)
+				return k8serr.IsNotFound(err)
+			}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+
+			By("Verifying namespace is cleaned up")
+			Eventually(func() bool {
+				ns := &core.Namespace{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: namespaceName}, ns)
+				return k8serr.IsNotFound(err) || ns.Status.Phase == "Terminating"
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("Should handle multiple simultaneous expirations", func() {
+			ctx := context.Background()
+
+			resNames := []string{"multi-expire-1", "multi-expire-2", "multi-expire-3"}
+
+			By("Creating multiple reservations with same short expiration")
+			for i, resName := range resNames {
+				res := helpers.NewReservation(resName, "3s", fmt.Sprintf("multi-user-%d", i), "default")
+				Expect(k8sClient.Create(ctx, res)).Should(Succeed())
+			}
+
+			By("Verifying all reservations are deleted after expiration")
+			for _, resName := range resNames {
+				Eventually(func() bool {
+					res := &crd.NamespaceReservation{}
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, res)
+					return k8serr.IsNotFound(err)
+				}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+			}
+		})
+	})
+})
+
+var _ = Describe("Reservation validation and edge cases", func() {
+	Context("When handling edge cases", func() {
+		It("Should handle reservations with missing required fields", func() {
+			ctx := context.Background()
+
+			By("Testing reservation without requester")
+			reservation := &crd.NamespaceReservation{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "cloud.redhat.com/v1alpha1",
+					Kind:       "NamespaceReservation",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-no-requester",
+				},
+				Spec: crd.NamespaceReservationSpec{
+					Duration: nil,
+					Pool:     "default",
+				},
+			}
+
+			err := k8sClient.Create(ctx, reservation)
+			// This should either fail validation or be handled gracefully
+			if err == nil {
+				updatedRes := &crd.NamespaceReservation{}
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: "test-no-requester"}, updatedRes)
+					return err == nil
+				}, timeout, interval).Should(BeTrue())
+			}
+		})
+
+		It("Should handle reservations with extremely long durations", func() {
+			ctx := context.Background()
+			resName := "test-long-duration"
+
+			reservation := helpers.NewReservation(resName, "8760h", "test-user-long", "default") // 1 year
+			Expect(k8sClient.Create(ctx, reservation)).Should(Succeed())
+
+			updatedReservation := &crd.NamespaceReservation{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, updatedReservation)
+				if err != nil {
+					return false
+				}
+				return updatedReservation.Status.State == "active" || updatedReservation.Status.State == "waiting"
+			}, timeout, interval).Should(BeTrue())
+
+			By("Verifying expiration time is set correctly")
+			if updatedReservation.Status.State == "active" {
+				Expect(updatedReservation.Status.Expiration.Time).To(BeTemporally(">", time.Now().Add(8759*time.Hour)))
+			}
+		})
+
+		It("Should handle concurrent reservation creation", func() {
+			ctx := context.Background()
+
+			By("Creating multiple reservations concurrently")
+			resNames := []string{"concurrent-1", "concurrent-2", "concurrent-3", "concurrent-4"}
+			errors := make(chan error, len(resNames))
+
+			for i, resName := range resNames {
+				go func(name string, index int) {
+					res := helpers.NewReservation(name, "30m", fmt.Sprintf("concurrent-user-%d", index), "default")
+					err := k8sClient.Create(ctx, res)
+					errors <- err
+				}(resName, i)
+			}
+
+			By("Verifying all creations complete without error")
+			for i := 0; i < len(resNames); i++ {
+				err := <-errors
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("Verifying all reservations have valid states")
+			for _, resName := range resNames {
+				res := &crd.NamespaceReservation{}
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, res)
+					if err != nil {
+						return false
+					}
+					return res.Status.State == "active" || res.Status.State == "waiting"
+				}, timeout, interval).Should(BeTrue())
+			}
+		})
+
+		It("Should handle reservation deletion during processing", func() {
+			ctx := context.Background()
+			resName := "test-early-delete"
+
+			reservation := helpers.NewReservation(resName, "1h", "test-user-early", "default")
+			Expect(k8sClient.Create(ctx, reservation)).Should(Succeed())
+
+			By("Deleting reservation immediately after creation")
+			Eventually(func() error {
+				res := &crd.NamespaceReservation{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, res)
+				if err != nil {
+					return err
+				}
+				return k8sClient.Delete(ctx, res)
+			}, timeout, interval).Should(Succeed())
+
+			By("Verifying reservation is deleted")
+			Eventually(func() bool {
+				res := &crd.NamespaceReservation{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, res)
+				return k8serr.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("Should handle reservation updates", func() {
+			ctx := context.Background()
+			resName := "test-update"
+
+			reservation := helpers.NewReservation(resName, "1h", "test-user-update", "default")
+			Expect(k8sClient.Create(ctx, reservation)).Should(Succeed())
+
+			updatedReservation := &crd.NamespaceReservation{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, updatedReservation)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("Updating reservation spec")
+			updatedReservation.Spec.Requester = "updated-user"
+			err := k8sClient.Update(ctx, updatedReservation)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying update is reflected")
+			Eventually(func() string {
+				res := &crd.NamespaceReservation{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, res)
+				if err != nil {
+					return ""
+				}
+				return res.Spec.Requester
+			}, timeout, interval).Should(Equal("updated-user"))
+		})
+	})
+})
+
+var _ = Describe("Reservation metrics and monitoring", func() {
+	Context("When reservation states change", func() {
+		It("Should track reservation state transitions", func() {
+			ctx := context.Background()
+			resName := "test-metrics"
+
+			reservation := helpers.NewReservation(resName, "30m", "test-user-metrics", "default")
+			Expect(k8sClient.Create(ctx, reservation)).Should(Succeed())
+
+			updatedReservation := &crd.NamespaceReservation{}
+
+			By("Tracking initial state")
+			Eventually(func() string {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, updatedReservation)
+				if err != nil {
+					return ""
+				}
+				return updatedReservation.Status.State
+			}, timeout, interval).Should(Or(Equal("active"), Equal("waiting")))
+
+			By("Verifying state is consistent")
+			Consistently(func() string {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, updatedReservation)
+				if err != nil {
+					return ""
+				}
+				return updatedReservation.Status.State
+			}, time.Second*2, time.Millisecond*500).Should(Or(Equal("active"), Equal("waiting")))
+		})
+
+		It("Should handle pool status updates from reservations", func() {
+			ctx := context.Background()
+			pool := crd.NamespacePool{}
+
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: "default"}, &pool)
+			Expect(err).NotTo(HaveOccurred())
+
+			originalReserved := pool.Status.Reserved
+
+			By("Creating a new reservation")
+			resName := "test-pool-update"
+			reservation := helpers.NewReservation(resName, "30m", "test-user-pool", "default")
+			Expect(k8sClient.Create(ctx, reservation)).Should(Succeed())
+
+			By("Verifying pool reserved count increases")
+			Eventually(func() int {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "default"}, &pool)
+				if err != nil {
+					return -1
+				}
+				return pool.Status.Reserved
+			}, timeout, interval).Should(BeNumerically(">=", originalReserved))
 		})
 	})
 })

--- a/controllers/cloud.redhat.com/suite_test.go
+++ b/controllers/cloud.redhat.com/suite_test.go
@@ -36,9 +36,13 @@ import (
 
 	clowder "github.com/RedHatInsights/clowder/apis/cloud.redhat.com/v1alpha1"
 	crd "github.com/RedHatInsights/ephemeral-namespace-operator/apis/cloud.redhat.com/v1alpha1"
+	"github.com/RedHatInsights/ephemeral-namespace-operator/controllers/cloud.redhat.com/helpers"
 	frontend "github.com/RedHatInsights/frontend-operator/api/v1alpha1"
 	utils "github.com/RedHatInsights/rhc-osdk-utils/utils"
 	core "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	//+kubebuilder:scaffold:imports
 )
@@ -88,6 +92,7 @@ func populateClowdEnvStatus(client client.Client) {
 				}
 				innerEnv.Status = status
 				err := client.Status().Update(ctx, &innerEnv)
+
 				if err != nil {
 					fmt.Println("ERROR: ", err)
 				}
@@ -131,64 +136,120 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	testPoolSpec := crd.NamespacePoolSpec{
-		Size:  2,
-		Local: true,
-		ClowdEnvironment: clowder.ClowdEnvironmentSpec{
-			Providers: clowder.ProvidersConfig{
-				Kafka: clowder.KafkaConfig{
-					Mode: "operator",
-					Cluster: clowder.KafkaClusterConfig{
-						Name:      "kafka",
-						Namespace: "kafka",
-						Replicas:  5,
-					},
-				},
-				Database: clowder.DatabaseConfig{
-					Mode: "local",
-				},
-				Logging: clowder.LoggingConfig{
-					Mode: "none",
-				},
-				ObjectStore: clowder.ObjectStoreConfig{
-					Mode: "minio",
-				},
-				InMemoryDB: clowder.InMemoryDBConfig{
-					Mode: "redis",
-				},
-				Web: clowder.WebConfig{
-					Port: int32(8000),
-					Mode: "none",
-				},
-				Metrics: clowder.MetricsConfig{
-					Port: int32(9000),
-					Path: "/metrics",
-					Mode: "none",
-				},
-				FeatureFlags: clowder.FeatureFlagsConfig{
-					Mode: "local",
-				},
-				Testing: clowder.TestingConfig{
-					ConfigAccess:   "environment",
-					K8SAccessLevel: "edit",
-					Iqe: clowder.IqeConfig{
-						ImageBase: "quay.io/cloudservices/iqe-tests",
-					},
-				},
-				AutoScaler: clowder.AutoScalerConfig{
-					Mode: "keda",
-				},
+	// Create a valid ClowdEnvironment spec for testing
+	testClowdEnvSpec := clowder.ClowdEnvironmentSpec{
+		Providers: clowder.ProvidersConfig{
+			Web: clowder.WebConfig{
+				Mode: "none",
 			},
-		},
-		LimitRange: core.LimitRange{
-			Spec: core.LimitRangeSpec{
-				Limits: []core.LimitRangeItem{},
+			Database: clowder.DatabaseConfig{
+				Mode: "none",
 			},
-		},
-		ResourceQuotas: core.ResourceQuotaList{
-			Items: []core.ResourceQuota{},
+			Logging: clowder.LoggingConfig{
+				Mode: "none",
+			},
+			Kafka: clowder.KafkaConfig{
+				Mode: "none",
+			},
+			ObjectStore: clowder.ObjectStoreConfig{
+				Mode: "none",
+			},
+			InMemoryDB: clowder.InMemoryDBConfig{
+				Mode: "none",
+			},
+			Metrics: clowder.MetricsConfig{
+				Mode: "none",
+			},
 		},
 	}
+
+	// Create LimitRange for testing
+	testLimitRange := core.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "resource-limits",
+		},
+		Spec: core.LimitRangeSpec{
+			Limits: []core.LimitRangeItem{
+				{
+					Type: core.LimitTypeContainer,
+					Default: map[core.ResourceName]resource.Quantity{
+						core.ResourceCPU:    resource.MustParse("200m"),
+						core.ResourceMemory: resource.MustParse("512Mi"),
+					},
+					DefaultRequest: map[core.ResourceName]resource.Quantity{
+						core.ResourceCPU:    resource.MustParse("100m"),
+						core.ResourceMemory: resource.MustParse("384Mi"),
+					},
+				},
+			},
+		},
+	}
+
+	// Create ResourceQuotas for testing
+	testResourceQuotas := core.ResourceQuotaList{
+		Items: []core.ResourceQuota{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "compute-resources",
+				},
+				Spec: core.ResourceQuotaSpec{
+					Hard: map[core.ResourceName]resource.Quantity{
+						"limits.cpu":    resource.MustParse("32"),
+						"limits.memory": resource.MustParse("64Gi"),
+					},
+				},
+			},
+		},
+	}
+
+	testPoolSpec := &crd.NamespacePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Spec: crd.NamespacePoolSpec{
+			Size:             2,
+			Local:            true,
+			ClowdEnvironment: testClowdEnvSpec,
+			LimitRange:       testLimitRange,
+			ResourceQuotas:   testResourceQuotas,
+		},
+	}
+
+	err = k8sClient.Create(context.Background(), testPoolSpec)
+	Expect(err).ToNot(HaveOccurred())
+
+	testPoolSpec2 := &crd.NamespacePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "minimal",
+		},
+		Spec: crd.NamespacePoolSpec{
+			Size:             2,
+			Local:            true,
+			ClowdEnvironment: testClowdEnvSpec,
+			LimitRange:       testLimitRange,
+			ResourceQuotas:   testResourceQuotas,
+		},
+	}
+
+	err = k8sClient.Create(context.Background(), testPoolSpec2)
+	Expect(err).ToNot(HaveOccurred())
+
+	testPoolSpec3 := &crd.NamespacePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "limit",
+		},
+		Spec: crd.NamespacePoolSpec{
+			Size:             2,
+			SizeLimit:        utils.IntPtr(3),
+			Local:            true,
+			ClowdEnvironment: testClowdEnvSpec,
+			LimitRange:       testLimitRange,
+			ResourceQuotas:   testResourceQuotas,
+		},
+	}
+
+	err = k8sClient.Create(context.Background(), testPoolSpec3)
+	Expect(err).ToNot(HaveOccurred())
 
 	poller := Poller{
 		client:             k8sManager.GetClient(),
@@ -196,18 +257,18 @@ var _ = BeforeSuite(func() {
 		log:                ctrl.Log.WithName("Poller"),
 	}
 
-	err = (&NamespacePoolReconciler{
-		client: k8sManager.GetClient(),
-		scheme: k8sManager.GetScheme(),
-		log:    ctrl.Log.WithName("controllers").WithName("NamespacePoolReconciler"),
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-
 	err = (&NamespaceReservationReconciler{
 		client: k8sManager.GetClient(),
 		scheme: k8sManager.GetScheme(),
 		poller: &poller,
-		log:    ctrl.Log.WithName("controllers").WithName("NamespaceReconciler"),
+		log:    ctrl.Log.WithName("controllers").WithName("ReservationController"),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&NamespacePoolReconciler{
+		client: k8sManager.GetClient(),
+		scheme: k8sManager.GetScheme(),
+		log:    ctrl.Log.WithName("controllers").WithName("NamespacePoolController"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -218,62 +279,467 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	stopController = cancel
-
-	defaultPool := &crd.NamespacePool{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "cloud.redhat.com/",
-			Kind:       "NamespacePool",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "default",
-		},
-		Spec: testPoolSpec,
-	}
-
-	minimalPool := &crd.NamespacePool{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "cloud.redhat.com/",
-			Kind:       "NamespacePool",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "minimal",
-		},
-		Spec: testPoolSpec,
-	}
-
-	limitPool := &crd.NamespacePool{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "cloud.redhat.com/",
-			Kind:       "NamespacePool",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "limit",
-		},
-		Spec: testPoolSpec,
-	}
-
-	limitPool.Spec.SizeLimit = utils.IntPtr(3)
-
-	Expect(k8sClient.Create(ctx, defaultPool)).Should(Succeed())
-	Expect(k8sClient.Create(ctx, minimalPool)).Should(Succeed())
-	Expect(k8sClient.Create(ctx, limitPool)).Should(Succeed())
-
-	go poller.Poll()
-
-	go populateClowdEnvStatus(k8sManager.GetClient())
-
 	go func() {
+		defer GinkgoRecover()
+		ctx, cancel := context.WithCancel(context.Background())
+		stopController = cancel
 		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
 
+	go populateClowdEnvStatus(k8sManager.GetClient())
 })
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
-	stopController()
+	if stopController != nil {
+		stopController()
+	}
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
+})
+
+// Helper function tests
+var _ = Describe("Helper Functions Unit Tests", func() {
+	Context("When testing annotation helpers", func() {
+		It("Should create proper initial annotations", func() {
+			annotations := helpers.CreateInitialAnnotations()
+
+			Expect(annotations).To(HaveKey("env-status"))
+			Expect(annotations).To(HaveKey("reserved"))
+			Expect(annotations["env-status"]).To(Equal("creating"))
+			Expect(annotations["reserved"]).To(Equal("false"))
+		})
+
+		It("Should create proper initial labels", func() {
+			poolName := "test-pool"
+			labels := helpers.CreateInitialLabels(poolName)
+
+			Expect(labels).To(HaveKey("operator-ns"))
+			Expect(labels).To(HaveKey("pool"))
+			Expect(labels["operator-ns"]).To(Equal("true"))
+			Expect(labels["pool"]).To(Equal(poolName))
+		})
+
+		It("Should convert custom annotations to map properly", func() {
+			annotation := helpers.CustomAnnotation{
+				Annotation: "test-key",
+				Value:      "test-value",
+			}
+
+			annotationMap := annotation.ToMap()
+			Expect(annotationMap).To(HaveLen(1))
+			Expect(annotationMap["test-key"]).To(Equal("test-value"))
+		})
+
+		It("Should convert custom labels to map properly", func() {
+			label := helpers.CustomLabel{
+				Label: "test-label",
+				Value: "test-value",
+			}
+
+			labelMap := label.ToMap()
+			Expect(labelMap).To(HaveLen(1))
+			Expect(labelMap["test-label"]).To(Equal("test-value"))
+		})
+
+		It("Should provide predefined annotation constants", func() {
+			By("Testing env status annotations")
+			Expect(helpers.AnnotationEnvReady.Annotation).To(Equal("env-status"))
+			Expect(helpers.AnnotationEnvReady.Value).To(Equal("ready"))
+
+			Expect(helpers.AnnotationEnvCreating.Annotation).To(Equal("env-status"))
+			Expect(helpers.AnnotationEnvCreating.Value).To(Equal("creating"))
+
+			Expect(helpers.AnnotationEnvError.Annotation).To(Equal("env-status"))
+			Expect(helpers.AnnotationEnvError.Value).To(Equal("error"))
+
+			Expect(helpers.AnnotationEnvDeleting.Annotation).To(Equal("env-status"))
+			Expect(helpers.AnnotationEnvDeleting.Value).To(Equal("deleting"))
+
+			By("Testing reserved annotations")
+			Expect(helpers.AnnotationReservedTrue.Annotation).To(Equal("reserved"))
+			Expect(helpers.AnnotationReservedTrue.Value).To(Equal("true"))
+
+			Expect(helpers.AnnotationReservedFalse.Annotation).To(Equal("reserved"))
+			Expect(helpers.AnnotationReservedFalse.Value).To(Equal("false"))
+
+			By("Testing label constants")
+			Expect(helpers.LabelOperatorNamespaceTrue.Label).To(Equal("operator-ns"))
+			Expect(helpers.LabelOperatorNamespaceTrue.Value).To(Equal("true"))
+		})
+	})
+
+	Context("When testing pool helper functions", func() {
+		It("Should correctly determine if pool is at limit", func() {
+			Expect(helpers.IsPoolAtLimit(0, 0)).To(BeTrue())
+			Expect(helpers.IsPoolAtLimit(5, 5)).To(BeTrue())
+			Expect(helpers.IsPoolAtLimit(3, 5)).To(BeFalse())
+			Expect(helpers.IsPoolAtLimit(7, 5)).To(BeFalse())
+		})
+
+		It("Should handle edge cases in pool limit checking", func() {
+			Expect(helpers.IsPoolAtLimit(-1, 5)).To(BeFalse())
+			Expect(helpers.IsPoolAtLimit(5, -1)).To(BeFalse())
+			Expect(helpers.IsPoolAtLimit(-1, -1)).To(BeTrue())
+			Expect(helpers.IsPoolAtLimit(0, 1)).To(BeFalse())
+			Expect(helpers.IsPoolAtLimit(1, 0)).To(BeFalse())
+		})
+
+		It("Should calculate namespace quantity delta correctly", func() {
+			By("Testing basic scenarios without size limit")
+			// No size limit, need 2 more ready namespaces
+			delta := helpers.CalculateNamespaceQuantityDelta(nil, 5, 3, 0, 0)
+			Expect(delta).To(Equal(2))
+
+			// No size limit, already at capacity
+			delta = helpers.CalculateNamespaceQuantityDelta(nil, 3, 3, 0, 0)
+			Expect(delta).To(Equal(0))
+
+			// No size limit, excess ready namespaces
+			delta = helpers.CalculateNamespaceQuantityDelta(nil, 2, 5, 0, 0)
+			Expect(delta).To(Equal(-3))
+
+			By("Testing scenarios with size limit")
+			// Size limit allows for creation
+			delta = helpers.CalculateNamespaceQuantityDelta(utils.IntPtr(10), 5, 2, 1, 2)
+			Expect(delta).To(Equal(2))
+
+			// Size limit blocks creation
+			delta = helpers.CalculateNamespaceQuantityDelta(utils.IntPtr(3), 5, 1, 1, 2)
+			Expect(delta).To(Equal(-1))
+
+			// Size limit exactly met
+			delta = helpers.CalculateNamespaceQuantityDelta(utils.IntPtr(5), 3, 2, 0, 3)
+			Expect(delta).To(Equal(1))
+		})
+
+		It("Should handle complex namespace quantity calculations", func() {
+			By("Testing with creating namespaces counted")
+			// Creating namespaces should be counted as part of queue
+			delta := helpers.CalculateNamespaceQuantityDelta(utils.IntPtr(5), 3, 1, 2, 1)
+			Expect(delta).To(Equal(0)) // 1 ready + 2 creating = 3, so no more needed
+
+			By("Testing size limit prioritization")
+			// Size limit should override size when more restrictive
+			delta = helpers.CalculateNamespaceQuantityDelta(utils.IntPtr(2), 10, 0, 0, 0)
+			Expect(delta).To(Equal(2)) // Limited by size limit, not size
+
+			By("Testing negative deltas for cleanup")
+			// Should return negative when over size limit
+			delta = helpers.CalculateNamespaceQuantityDelta(utils.IntPtr(3), 2, 3, 0, 2)
+			Expect(delta).To(Equal(-2)) // Total is 5, limit is 3, so remove 2
+		})
+	})
+
+	Context("When testing namespace utility functions", func() {
+		It("Should handle ready status checking", func() {
+			ctx := context.Background()
+
+			// Create a test namespace
+			ns := core.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ready-status",
+					Labels: map[string]string{
+						"pool": "test-pool",
+					},
+					Annotations: map[string]string{
+						"env-status": "ready",
+					},
+				},
+			}
+
+			err := k8sClient.Create(ctx, &ns)
+			if err != nil && !k8serr.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			// Test CheckReadyStatus function
+			var ready []core.Namespace
+			result := helpers.CheckReadyStatus("test-pool", ns, ready)
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].Name).To(Equal("test-ready-status"))
+
+			// Test with non-matching pool
+			result = helpers.CheckReadyStatus("different-pool", ns, ready)
+			Expect(result).To(HaveLen(0))
+
+			// Test with non-ready status
+			ns.Annotations["env-status"] = "creating"
+			result = helpers.CheckReadyStatus("test-pool", ns, ready)
+			Expect(result).To(HaveLen(0))
+		})
+
+		It("Should create proper reservation objects", func() {
+			By("Testing NewReservation helper")
+			res := helpers.NewReservation("test-res", "1h", "test-user", "test-pool")
+
+			Expect(res.Name).To(Equal("test-res"))
+			Expect(res.Spec.Requester).To(Equal("test-user"))
+			Expect(res.Spec.Pool).To(Equal("test-pool"))
+			Expect(*res.Spec.Duration).To(Equal("1h"))
+			Expect(res.TypeMeta.Kind).To(Equal("NamespaceReservation"))
+		})
+
+		It("Should handle reservation creation with empty values", func() {
+			By("Testing NewReservation with empty duration")
+			res := helpers.NewReservation("test-empty", "", "user", "pool")
+			Expect(res.Spec.Duration).To(BeNil())
+
+			By("Testing NewReservation with empty pool")
+			res = helpers.NewReservation("test-empty-pool", "1h", "user", "")
+			Expect(res.Spec.Pool).To(Equal(""))
+
+			By("Testing NewReservation with empty requester")
+			res = helpers.NewReservation("test-empty-user", "1h", "", "pool")
+			Expect(res.Spec.Requester).To(Equal(""))
+		})
+	})
+
+	Context("When testing constant definitions", func() {
+		It("Should have correct constant values", func() {
+			By("Testing annotation constants")
+			Expect(helpers.AnnotationEnvStatus).To(Equal("env-status"))
+			Expect(helpers.AnnotationReserved).To(Equal("reserved"))
+			Expect(helpers.CompletionTime).To(Equal("completion-time"))
+
+			By("Testing status value constants")
+			Expect(helpers.EnvStatusCreating).To(Equal("creating"))
+			Expect(helpers.EnvStatusDeleting).To(Equal("deleting"))
+			Expect(helpers.EnvStatusError).To(Equal("error"))
+			Expect(helpers.EnvStatusReady).To(Equal("ready"))
+
+			By("Testing label constants")
+			Expect(helpers.LabelOperatorNS).To(Equal("operator-ns"))
+			Expect(helpers.LabelPool).To(Equal("pool"))
+
+			By("Testing kind constants")
+			Expect(helpers.KindNamespacePool).To(Equal("NamespacePool"))
+
+			By("Testing namespace constants")
+			Expect(helpers.NamespaceEphemeralBase).To(Equal("ephemeral-base"))
+
+			By("Testing secret constants")
+			Expect(helpers.BonfireGinoreSecret).To(Equal("bonfire.ignore"))
+			Expect(helpers.OpenShiftVaultSecretsSecret).To(Equal("openshift-vault-secrets"))
+			Expect(helpers.QontractIntegrationSecret).To(Equal("qontract.integration"))
+
+			By("Testing boolean constants")
+			Expect(helpers.TrueValue).To(Equal("true"))
+			Expect(helpers.FalseValue).To(Equal("false"))
+		})
+	})
+})
+
+// Poller tests
+var _ = Describe("Poller Unit Tests", func() {
+	Context("When testing Poller functionality", func() {
+		It("Should correctly identify expired namespaces", func() {
+			poller := &Poller{}
+
+			By("Testing with future expiration time")
+			futureTime := metav1.NewTime(time.Now().Add(1 * time.Hour))
+			Expect(poller.namespaceIsExpired(futureTime)).To(BeFalse())
+
+			By("Testing with past expiration time")
+			pastTime := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+			Expect(poller.namespaceIsExpired(pastTime)).To(BeTrue())
+
+			By("Testing with zero time")
+			zeroTime := metav1.Time{}
+			Expect(poller.namespaceIsExpired(zeroTime)).To(BeFalse())
+
+			By("Testing with current time (should be expired)")
+			currentTime := metav1.NewTime(time.Now().Add(-1 * time.Second))
+			Expect(poller.namespaceIsExpired(currentTime)).To(BeTrue())
+		})
+
+		It("Should handle edge cases in expiration checking", func() {
+			poller := &Poller{}
+
+			By("Testing with very recent past time")
+			recentPast := metav1.NewTime(time.Now().Add(-1 * time.Millisecond))
+			Expect(poller.namespaceIsExpired(recentPast)).To(BeTrue())
+
+			By("Testing with very near future time")
+			nearFuture := metav1.NewTime(time.Now().Add(1 * time.Millisecond))
+			Expect(poller.namespaceIsExpired(nearFuture)).To(BeFalse())
+		})
+
+		It("Should populate active reservations correctly", func() {
+			ctx := context.Background()
+			poller := &Poller{
+				client:             k8sClient,
+				activeReservations: make(map[string]metav1.Time),
+				log:                ctrl.Log.WithName("TestPoller"),
+			}
+
+			By("Creating test reservations")
+			activeRes := helpers.NewReservation("active-res", "1h", "test-user", "default")
+			err := k8sClient.Create(ctx, activeRes)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Update to active state
+			Eventually(func() error {
+				updatedRes := &crd.NamespaceReservation{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "active-res"}, updatedRes)
+				if err != nil {
+					return err
+				}
+				updatedRes.Status.State = "active"
+				updatedRes.Status.Expiration = metav1.NewTime(time.Now().Add(1 * time.Hour))
+				return k8sClient.Status().Update(ctx, updatedRes)
+			}, time.Second*10, time.Millisecond*100).Should(Succeed())
+
+			By("Testing populateActiveReservations")
+			err = poller.populateActiveReservations(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying active reservation was added")
+			Eventually(func() bool {
+				_, exists := poller.activeReservations["active-res"]
+				return exists
+			}, time.Second*5, time.Millisecond*100).Should(BeTrue())
+		})
+
+		It("Should get existing reservations", func() {
+			ctx := context.Background()
+			poller := &Poller{
+				client:             k8sClient,
+				activeReservations: make(map[string]metav1.Time),
+				log:                ctrl.Log.WithName("TestPoller"),
+			}
+
+			resList, err := poller.getExistingReservations(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resList).NotTo(BeNil())
+			Expect(len(resList.Items)).To(BeNumerically(">=", 0))
+		})
+	})
+
+	Context("When testing Poller edge cases", func() {
+		It("Should handle empty reservation lists", func() {
+			ctx := context.Background()
+			poller := &Poller{
+				client:             k8sClient,
+				activeReservations: make(map[string]metav1.Time),
+				log:                ctrl.Log.WithName("TestPoller"),
+			}
+
+			resList, err := poller.getExistingReservations(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resList.Items).NotTo(BeNil())
+		})
+
+		It("Should handle activeReservations map operations", func() {
+			poller := &Poller{
+				activeReservations: make(map[string]metav1.Time),
+				log:                ctrl.Log.WithName("TestPoller"),
+			}
+
+			By("Testing map operations")
+			testTime := metav1.NewTime(time.Now())
+			poller.activeReservations["test-res"] = testTime
+
+			Expect(poller.activeReservations).To(HaveKey("test-res"))
+			Expect(poller.activeReservations["test-res"]).To(Equal(testTime))
+
+			delete(poller.activeReservations, "test-res")
+			Expect(poller.activeReservations).NotTo(HaveKey("test-res"))
+		})
+
+		It("Should verify poll cycle constant", func() {
+			Expect(PollCycle).To(Equal(time.Duration(10)))
+		})
+	})
+})
+
+// Integration tests for complex scenarios
+var _ = Describe("Integration Test Scenarios", func() {
+	Context("When testing complex workflows", func() {
+		It("Should handle multiple pools with different configurations", func() {
+			ctx := context.Background()
+
+			By("Verifying different pool configurations exist")
+			pools := []string{"default", "minimal", "limit"}
+			for _, poolName := range pools {
+				pool := &crd.NamespacePool{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: poolName}, pool)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pool.Name).To(Equal(poolName))
+			}
+
+			By("Verifying pool-specific configurations")
+			limitPool := &crd.NamespacePool{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: "limit"}, limitPool)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(limitPool.Spec.SizeLimit).NotTo(BeNil())
+			Expect(*limitPool.Spec.SizeLimit).To(Equal(3))
+		})
+
+		It("Should handle cross-pool reservation scenarios", func() {
+			ctx := context.Background()
+
+			By("Creating reservations across different pools")
+			res1 := helpers.NewReservation("cross-pool-1", "30m", "user1", "default")
+			res2 := helpers.NewReservation("cross-pool-2", "30m", "user2", "minimal")
+			res3 := helpers.NewReservation("cross-pool-3", "30m", "user3", "limit")
+
+			Expect(k8sClient.Create(ctx, res1)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, res2)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, res3)).Should(Succeed())
+
+			By("Verifying reservations are processed by correct pools")
+			Eventually(func() bool {
+				var allProcessed bool = true
+
+				for _, resName := range []string{"cross-pool-1", "cross-pool-2", "cross-pool-3"} {
+					res := &crd.NamespaceReservation{}
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, res)
+					if err != nil || (res.Status.State != "active" && res.Status.State != "waiting") {
+						allProcessed = false
+						break
+					}
+				}
+
+				return allProcessed
+			}, time.Second*30, time.Millisecond*500).Should(BeTrue())
+		})
+
+		It("Should handle stress testing with multiple concurrent operations", func() {
+			ctx := context.Background()
+
+			By("Creating multiple reservations simultaneously")
+			resNames := []string{}
+			for i := 0; i < 5; i++ {
+				resName := fmt.Sprintf("stress-test-%d", i)
+				resNames = append(resNames, resName)
+
+				res := helpers.NewReservation(resName, "15m", fmt.Sprintf("stress-user-%d", i), "default")
+				Expect(k8sClient.Create(ctx, res)).Should(Succeed())
+			}
+
+			By("Verifying all reservations are eventually processed")
+			Eventually(func() int {
+				processedCount := 0
+				for _, resName := range resNames {
+					res := &crd.NamespaceReservation{}
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, res)
+					if err == nil && (res.Status.State == "active" || res.Status.State == "waiting") {
+						processedCount++
+					}
+				}
+				return processedCount
+			}, time.Second*30, time.Millisecond*250).Should(Equal(5))
+
+			By("Cleaning up stress test reservations")
+			for _, resName := range resNames {
+				res := &crd.NamespaceReservation{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: resName}, res)
+				if err == nil {
+					k8sClient.Delete(ctx, res)
+				}
+			}
+		})
+	})
 })


### PR DESCRIPTION
# Description

This PR adds support for application dependencies to be referenced from external clusters. A new CRD called ClowdAppRef has been added which allows users to define these dependencies in their ClowdApps.

Assisted-By: Cursor v1.2.4 / claude-4-sonnet