### PR TITLE
Revert last two PRs (#562 and #561)

### DIFF
--- a/dashboards/ephemeral-ns-operator-dashboard.yaml
+++ b/dashboards/ephemeral-ns-operator-dashboard.yaml
@@ -352,7 +352,7 @@ data:
               "dimensions": {},
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sort_desc(sum by(user) (label_replace(res_quantity_by_user_count{user!~\".*smoke-test.*|.*pr-check-.*|automation-.*|.*-check-bot|.*ephemeral-base.*|edge-api.*|notifications.*\"}, \"user\", \"$1\", \"user\", \"(.+)-[a-z0-9]{5}$\")))",
+              "expr": "sort_desc(sum by(user) (res_quantity_by_user_count{user!~\".*smoke-test.*|.*pr-check-.*|automation-.*|.*-check-bot|.*ephemeral-base.*|edge-api.*|notifications.*\"}))",
               "expression": "",
               "format": "table",
               "id": "",

--- a/dashboards/ephemeral-ns-operator-dashboard.yaml
+++ b/dashboards/ephemeral-ns-operator-dashboard.yaml
@@ -352,7 +352,7 @@ data:
               "dimensions": {},
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sort_desc(sum by(user) (label_replace(sum by(user) (res_quantity_by_user_count{user!~\".*smoke-test.*|.*pr-check-.*|automation-.*|.*-check-bot|.*ephemeral-base.*|edge-api.*|notifications.*\"}), \"user\", \"$1\", \"user\", \"(.+)-[a-z0-9]{5}$\")))",
+              "expr": "sort_desc(sum by(user) (label_replace(res_quantity_by_user_count{user!~\".*smoke-test.*|.*pr-check-.*|automation-.*|.*-check-bot|.*ephemeral-base.*|edge-api.*|notifications.*\"}, \"user\", \"$1\", \"user\", \"(.+)-[a-z0-9]{5}$\")))",
               "expression": "",
               "format": "table",
               "id": "",


### PR DESCRIPTION
## Summary

This PR reverts the last two merged PRs that are not working properly:

- Reverts PR #562: "fix: pre-aggregate user metrics before label_replace in dashboard query"
- Reverts PR #561: "Consolidate user names and ignore unique identifiers"

## Reverted Commits

- `121cd16` - fix: pre-aggregate user metrics before label_replace in dashboard query (#562)
- `c6b6fb0` - Consolidate user names and ignore unique identifiers (#561)

## Reason

These PRs are not working properly and need to be reverted to restore previous functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)