### PR TITLE
fix: re-fetch namespace on conflict retry in UpdateAnnotations

### DIFF
--- a/controllers/cloud.redhat.com/helpers/namespaces.go
+++ b/controllers/cloud.redhat.com/helpers/namespaces.go
@@ -159,16 +159,16 @@ func CheckReadyStatus(pool string, namespace core.Namespace, ready []core.Namesp
 
 // UpdateAnnotations updates annotations on a namespace with retry logic
 func UpdateAnnotations(ctx context.Context, cl client.Client, namespaceName string, annotations map[string]string) error {
-	namespace, err := GetNamespace(ctx, cl, namespaceName)
-	if err != nil {
-		return fmt.Errorf("error updating annotations for namespace [%s]: %w", namespaceName, err)
-	}
-
-	utils.UpdateAnnotations(&namespace, annotations)
-
-	err = retry.RetryOnConflict(
+	return retry.RetryOnConflict(
 		retry.DefaultBackoff,
 		func() error {
+			namespace, err := GetNamespace(ctx, cl, namespaceName)
+			if err != nil {
+				return fmt.Errorf("error updating annotations for namespace [%s]: %w", namespaceName, err)
+			}
+
+			utils.UpdateAnnotations(&namespace, annotations)
+
 			if err = cl.Update(ctx, &namespace); err != nil {
 				return fmt.Errorf("there was an issue updating annotations for namespace [%s]: %w", namespaceName, err)
 			}
@@ -176,8 +176,6 @@ func UpdateAnnotations(ctx context.Context, cl client.Client, namespaceName stri
 			return nil
 		},
 	)
-
-	return nil
 }
 
 func logSecretCopyOperation(log logr.Logger, message string, srcNamespace, targetNamespace string, secretNames []string) {


### PR DESCRIPTION
## Summary

- `UpdateAnnotations` fetched the namespace object once *before* the `RetryOnConflict` loop, so every retry attempt used the same stale resource version — all retries would fail with the same conflict error
- The function also unconditionally returned `nil`, silently swallowing the failure and causing `UpdateNamespaceResources` to log "successfully created" even when the ready annotation was never applied

## Impact

Namespaces in pools with no `ClowdEnvironment` (e.g. the `rosa` pool) get stuck in `creating` state permanently. Because the pool counts stuck `creating` namespaces toward its size quota, it never provisions replacements either — the pool stays perpetually empty.

Pools with a ClowdEnvironment were not affected: the `ClowdenvironmentReconciler` requeues the entire reconciliation on error, re-fetching fresh state each time, so conflicts were retried correctly at that level.

## Root cause (confirmed from operator logs)

At namespace creation time, OpenShift controllers (Tekton, OLM, workload-monitoring, pod-security admission) all write to the new namespace within milliseconds. By the time the operator calls `UpdateAnnotations` to set `env-status: ready`, the resource version is already stale → conflict → silent failure.

## Fix

Move `GetNamespace` inside the retry callback so each attempt works with a fresh resource version, and return the result of `RetryOnConflict` so callers receive real errors.

## Test plan

- [x] `make fmt vet` — clean
- [x] `make test` — 93/93 tests pass (53 helper + 40 controller)
- [x] Verified against live cluster: `ephemeral-askzvl` in `rosa` pool confirmed stuck due to this exact bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)