### PR TITLE
Fix/update annotations conflict retry

### DIFF
--- a/controllers/cloud.redhat.com/helpers/namespaces.go
+++ b/controllers/cloud.redhat.com/helpers/namespaces.go
@@ -43,16 +43,21 @@ func CreateNamespace(ctx context.Context, cl client.Client, pool *crd.NamespaceP
 
 // UpdateNamespaceResources configures a namespace with pool-defined resources including ClowdEnvironment, LimitRange, ResourceQuotas, and secrets
 func UpdateNamespaceResources(ctx context.Context, cl client.Client, pool *crd.NamespacePool, nsName string) (core.Namespace, error) {
-	ns, err := GetNamespace(ctx, cl, nsName)
-	if err != nil {
-		return ns, fmt.Errorf("could not retrieve namespace [%s]: %w", nsName, err)
-	}
-
-	utils.UpdateAnnotations(&ns, CreateInitialAnnotations())
-	utils.UpdateLabels(&ns, CreateInitialLabels(pool.Name))
-	ns.SetOwnerReferences([]metav1.OwnerReference{pool.MakeOwnerReference()})
-
-	if err := cl.Update(ctx, &ns); err != nil {
+	var ns core.Namespace
+	if err := retry.RetryOnConflict(
+		retry.DefaultBackoff,
+		func() error {
+			var err error
+			ns, err = GetNamespace(ctx, cl, nsName)
+			if err != nil {
+				return fmt.Errorf("could not retrieve namespace [%s]: %w", nsName, err)
+			}
+			utils.UpdateAnnotations(&ns, CreateInitialAnnotations())
+			utils.UpdateLabels(&ns, CreateInitialLabels(pool.Name))
+			ns.SetOwnerReferences([]metav1.OwnerReference{pool.MakeOwnerReference()})
+			return cl.Update(ctx, &ns)
+		},
+	); err != nil {
 		return ns, fmt.Errorf("could not update Project [%s]: %w", nsName, err)
 	}
 


### PR DESCRIPTION
## Summary

Fixes a conflict race on the initial `cl.Update` in `UpdateNamespaceResources` that caused no-ClowdEnvironment pools (e.g. `rosa`) to stay empty after the `UpdateAnnotations` fix in #568.

After namespace creation, OpenShift controllers (Tekton, OLM, workload-monitoring) immediately update the namespace, advancing its resource version. The subsequent update to set the `pool` label, `env-status: creating`, and the ownerRef then fails with a conflict. With no retry, the namespace is deleted — but since it never received the `pool` label, its deletion does not trigger the `EnqueueNamespace` watcher. The pool controller stops reconciling and the pool stays perpetually empty.

Wraps the initial fetch+update in `RetryOnConflict`, re-fetching the namespace inside the retry callback so each attempt uses the current resource version.

## Test plan

- [x] `make fmt vet` — clean
- [x] `make test` — 93/93 tests pass (53 helper + 40 controller)
- [x] Confirmed on live cluster via operator logs after #568 was deployed — pool still stuck due to this second conflict point
- [x] JIRA: [ENGPROD-9889](https://redhat.atlassian.net/browse/ENGPROD-9889)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENGPROD-9889]: https://redhat.atlassian.net/browse/ENGPROD-9889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ