### PR TITLE
fix: delete and re-copy secrets when reservation overrides secretSourceNamespace

### DIFF
--- a/controllers/cloud.redhat.com/helpers/helpers_test.go
+++ b/controllers/cloud.redhat.com/helpers/helpers_test.go
@@ -817,7 +817,7 @@ var _ = Describe("Helper Functions", func() {
 				WithObjects(customSrcNs, targetNs, secret).
 				Build()
 
-			err := CopySecretsFrom(ctx, fakeClient, "custom-base", "target-ns")
+			err := CopySecretsFrom(ctx, fakeClient, "custom-base", "target-ns", false)
 			Expect(err).ToNot(HaveOccurred())
 
 			copiedSecret := &core.Secret{}
@@ -863,7 +863,7 @@ var _ = Describe("Helper Functions", func() {
 				WithObjects(customSrcNs, targetNs, secretNoAnnotation, secretWithAnnotation).
 				Build()
 
-			err := CopySecretsFrom(ctx, fakeClient, "custom-base", "target-ns")
+			err := CopySecretsFrom(ctx, fakeClient, "custom-base", "target-ns", false)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Annotated secret should be copied
@@ -908,7 +908,7 @@ var _ = Describe("Helper Functions", func() {
 				WithObjects(customSrcNs, targetNs, secretIgnored).
 				Build()
 
-			err := CopySecretsFrom(ctx, fakeClient, "custom-base", "target-ns")
+			err := CopySecretsFrom(ctx, fakeClient, "custom-base", "target-ns", false)
 			Expect(err).ToNot(HaveOccurred())
 
 			missingSecret := &core.Secret{}
@@ -929,7 +929,7 @@ var _ = Describe("Helper Functions", func() {
 				WithObjects(customSrcNs).
 				Build()
 
-			err := CopySecretsFrom(ctx, fakeClient, "empty-base", "target-ns")
+			err := CopySecretsFrom(ctx, fakeClient, "empty-base", "target-ns", false)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/controllers/cloud.redhat.com/helpers/namespaces.go
+++ b/controllers/cloud.redhat.com/helpers/namespaces.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 	core "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -89,7 +90,7 @@ func UpdateNamespaceResources(ctx context.Context, cl client.Client, pool *crd.N
 	if pool.Spec.DefaultSecretSourceNamespace != "" {
 		srcNs = pool.Spec.DefaultSecretSourceNamespace
 	}
-	if err := CopySecretsFrom(ctx, cl, srcNs, nsName); err != nil {
+	if err := CopySecretsFrom(ctx, cl, srcNs, nsName, false); err != nil {
 		return ns, fmt.Errorf("error copying secrets from [%s] to namespace [%s]: %w", srcNs, nsName, err)
 	}
 
@@ -192,8 +193,9 @@ func logSecretCopyOperation(log logr.Logger, message string, srcNamespace, targe
 	)
 }
 
-// CopySecretsFrom copies secrets from any source namespace to the target namespace
-func CopySecretsFrom(ctx context.Context, cl client.Client, srcNamespace, namespaceName string) error {
+// CopySecretsFrom copies secrets from any source namespace to the target namespace.
+// When overwrite is true, any secret that already exists in the target is deleted and re-copied from the source.
+func CopySecretsFrom(ctx context.Context, cl client.Client, srcNamespace, namespaceName string, overwrite bool) error {
 	// Extract logger from context or create a default one
 	log := ctrl.Log.WithName("secret-copy")
 	if logPtr := ctx.Value(ContextKey("log")); logPtr != nil {
@@ -259,6 +261,35 @@ func CopySecretsFrom(ctx context.Context, cl client.Client, srcNamespace, namesp
 		}
 
 		if err := cl.Create(ctx, newNamespaceSecret); err != nil {
+			if k8serr.IsAlreadyExists(err) {
+				if overwrite {
+					existing := &core.Secret{}
+					existing.Name = secret.Name
+					existing.Namespace = namespaceName
+					if delErr := cl.Delete(ctx, existing); delErr != nil {
+						secretsFailed = append(secretsFailed, secret.Name)
+						log.Error(delErr, "SECRET_COPY_OPS: Failed to delete existing secret for overwrite",
+							"operation", "delete_secret",
+							"source_namespace", secret.Namespace,
+							"target_namespace", namespaceName,
+							"secret_names", []string{secret.Name},
+						)
+						continue
+					}
+					if createErr := cl.Create(ctx, newNamespaceSecret); createErr != nil {
+						secretsFailed = append(secretsFailed, secret.Name)
+						log.Error(createErr, "SECRET_COPY_OPS: Failed to re-create secret after overwrite",
+							"operation", "create_secret",
+							"source_namespace", secret.Namespace,
+							"target_namespace", namespaceName,
+							"secret_names", []string{secret.Name},
+						)
+						continue
+					}
+				}
+				secretsSuccessful = append(secretsSuccessful, secret.Name)
+				continue
+			}
 			secretsFailed = append(secretsFailed, secret.Name)
 			log.Error(err, "SECRET_COPY_OPS: Failed to create secret in target namespace",
 				"operation", "create_secret",
@@ -328,7 +359,7 @@ func CopySecretsFrom(ctx context.Context, cl client.Client, srcNamespace, namesp
 
 // CopySecrets copies secrets from ephemeral-base to the target namespace (backward-compatible wrapper)
 func CopySecrets(ctx context.Context, cl client.Client, namespaceName string) error {
-	return CopySecretsFrom(ctx, cl, NamespaceEphemeralBase, namespaceName)
+	return CopySecretsFrom(ctx, cl, NamespaceEphemeralBase, namespaceName, false)
 }
 
 // DeleteNamespace marks a namespace for deletion and removes it from the cluster

--- a/controllers/cloud.redhat.com/namespacereservation_controller.go
+++ b/controllers/cloud.redhat.com/namespacereservation_controller.go
@@ -260,7 +260,7 @@ func (r *NamespaceReservationReconciler) reserveNamespace(ctx context.Context, r
 	// If the reservation specifies a secret source namespace, copy secrets from it
 	if res.Spec.SecretSourceNamespace != "" {
 		r.log.Info(fmt.Sprintf("copying secrets from [%s] into namespace [%s] per reservation spec", res.Spec.SecretSourceNamespace, readyNsName))
-		if err := helpers.CopySecretsFrom(ctx, r.client, res.Spec.SecretSourceNamespace, readyNsName); err != nil {
+		if err := helpers.CopySecretsFrom(ctx, r.client, res.Spec.SecretSourceNamespace, readyNsName, true); err != nil {
 			r.log.Error(err, "could not copy secrets from reservation secret source namespace", "source", res.Spec.SecretSourceNamespace, "namespace", readyNsName)
 			return err
 		}


### PR DESCRIPTION
## Summary

- When a pool provisions a namespace, secrets are copied from the pool's `defaultSecretSourceNamespace` into it
- If a `NamespaceReservation` then specifies the same `secretSourceNamespace`, `CopySecretsFrom` called `cl.Create` on each secret and failed with `already exists`, blocking namespace assignment indefinitely via exponential backoff
- Confirmed on live cluster: `bonfire-reservation-1b23c25a` spent ~10 minutes retrying before finally assigning due to an unrelated code path, then immediately expired

## Fix

Added an `overwrite bool` parameter to `CopySecretsFrom`:

- **`overwrite=false`** (pool provisioning): if a secret already exists in the target namespace, treat it as a no-op success — the pre-provisioned copy is fine
- **`overwrite=true`** (reservation with explicit `secretSourceNamespace`): delete the existing copy and re-create from the specified source — the reservation's intent overrides whatever was pre-populated

## Test plan

- [x] `make fmt vet` — clean
- [x] `make test` — 93/93 tests pass (53 helper + 40 controller)
- [x] Root cause confirmed in operator logs on live cluster
- [x] JIRA: [ENGPROD-9889](https://redhat.atlassian.net/browse/ENGPROD-9889)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENGPROD-9889]: https://redhat.atlassian.net/browse/ENGPROD-9889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ