### PR TITLE
feat: add CAPI cleanup finalizer to NamespaceReservation

### DIFF
--- a/controllers/cloud.redhat.com/helpers/capi.go
+++ b/controllers/cloud.redhat.com/helpers/capi.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -12,9 +13,13 @@ import (
 // DeleteCAPIResources deletes all Cluster resources in the given namespace and reports whether any remain.
 // The caller should requeue if this returns true, allowing CAPI controllers time to run their
 // finalizers (which require rosa-creds-secret to be present) before the namespace is GC'd.
+// Returns (false, nil) when the Cluster CRD is not installed on the cluster.
 func DeleteCAPIResources(ctx context.Context, cl client.Client, namespace string) (bool, error) {
 	clusterList := clusterv1.ClusterList{}
 	if err := cl.List(ctx, &clusterList, client.InNamespace(namespace)); err != nil {
+		if apimeta.IsNoMatchError(err) {
+			return false, nil
+		}
 		return false, fmt.Errorf("could not list Cluster resources in [%s]: %w", namespace, err)
 	}
 

--- a/controllers/cloud.redhat.com/helpers/capi.go
+++ b/controllers/cloud.redhat.com/helpers/capi.go
@@ -1,0 +1,31 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DeleteCAPIResources deletes all Cluster resources in the given namespace and reports whether any remain.
+// The caller should requeue if this returns true, allowing CAPI controllers time to run their
+// finalizers (which require rosa-creds-secret to be present) before the namespace is GC'd.
+func DeleteCAPIResources(ctx context.Context, cl client.Client, namespace string) (bool, error) {
+	clusterList := clusterv1.ClusterList{}
+	if err := cl.List(ctx, &clusterList, client.InNamespace(namespace)); err != nil {
+		return false, fmt.Errorf("could not list Cluster resources in [%s]: %w", namespace, err)
+	}
+
+	for i := range clusterList.Items {
+		cluster := &clusterList.Items[i]
+		if cluster.DeletionTimestamp.IsZero() {
+			if err := cl.Delete(ctx, cluster); err != nil && !k8serr.IsNotFound(err) {
+				return false, fmt.Errorf("could not delete Cluster [%s/%s]: %w", namespace, cluster.Name, err)
+			}
+		}
+	}
+
+	return len(clusterList.Items) > 0, nil
+}

--- a/controllers/cloud.redhat.com/helpers/helpers_test.go
+++ b/controllers/cloud.redhat.com/helpers/helpers_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Helper Functions", func() {
 		Expect(core.AddToScheme(scheme)).To(Succeed())
 		Expect(clowder.AddToScheme(scheme)).To(Succeed())
 		Expect(crd.AddToScheme(scheme)).To(Succeed())
+		Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
 
 		fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
 		logger = log.Log.WithName("test-helpers")
@@ -931,6 +932,68 @@ var _ = Describe("Helper Functions", func() {
 
 			err := CopySecretsFrom(ctx, fakeClient, "empty-base", "target-ns")
 			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("DeleteCAPIResources", func() {
+		BeforeEach(func() {
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+		})
+
+		It("should return false when no Cluster resources exist in the namespace", func() {
+			remaining, err := DeleteCAPIResources(ctx, fakeClient, "test-ns")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(remaining).To(BeFalse())
+		})
+
+		It("should delete Cluster resources and return true while they still exist", func() {
+			cluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+				},
+			}
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+
+			remaining, err := DeleteCAPIResources(ctx, fakeClient, "test-ns")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(remaining).To(BeTrue())
+		})
+
+		It("should not attempt to delete Cluster resources already being deleted", func() {
+			now := metav1.Now()
+			cluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "terminating-cluster",
+					Namespace:         "test-ns",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{"test-finalizer"},
+				},
+			}
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+
+			remaining, err := DeleteCAPIResources(ctx, fakeClient, "test-ns")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(remaining).To(BeTrue())
+
+			// Verify the cluster still exists (was not deleted again)
+			fetched := &clusterv1.Cluster{}
+			err = fakeClient.Get(ctx, types.NamespacedName{Name: "terminating-cluster", Namespace: "test-ns"}, fetched)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should ignore Clusters in other namespaces", func() {
+			cluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-ns-cluster",
+					Namespace: "other-ns",
+				},
+			}
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+
+			remaining, err := DeleteCAPIResources(ctx, fakeClient, "test-ns")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(remaining).To(BeFalse())
 		})
 	})
 })

--- a/controllers/cloud.redhat.com/namespacereservation_controller.go
+++ b/controllers/cloud.redhat.com/namespacereservation_controller.go
@@ -51,12 +51,13 @@ type NamespaceReservationReconciler struct {
 	log    logr.Logger
 }
 
+const capiCleanupFinalizer = "capi-cleanup.cloud.redhat.com"
+const capiCleanupTimeout = 1 * time.Hour
+
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=namespacereservations,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=namespacereservations/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=namespacereservations/finalizers,verbs=update
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch;delete
-
-const capiCleanupFinalizer = "capi-cleanup.cloud.redhat.com"
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=clowdenvironments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=frontendenvironments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets;events;namespaces;limitranges;resourcequotas,verbs=get;list;watch;create;update;patch;delete
@@ -98,6 +99,13 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 	switch res.Status.State {
 	case "active":
 		log.Info("Reconciling active reservation", "name", res.Name, "namespace", res.Status.Namespace)
+		if !controllerutil.ContainsFinalizer(&res, capiCleanupFinalizer) {
+			controllerutil.AddFinalizer(&res, capiCleanupFinalizer)
+			if err := r.client.Update(ctx, &res); err != nil {
+				log.Error(err, "could not add CAPI cleanup finalizer", "res-name", res.Name)
+				return ctrl.Result{}, err
+			}
+		}
 		expirationTS, err := getExpirationTime(&res)
 		if err != nil {
 			r.log.Error(err, "Could not get expiration time for reservation", "name", res.Name)
@@ -196,15 +204,6 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 			return ctrl.Result{Requeue: true}, err
 		}
 
-		// Add finalizer to gate namespace GC on CAPI resource cleanup
-		if !controllerutil.ContainsFinalizer(&res, capiCleanupFinalizer) {
-			controllerutil.AddFinalizer(&res, capiCleanupFinalizer)
-			if err := r.client.Update(ctx, &res); err != nil {
-				log.Error(err, "could not add CAPI cleanup finalizer", "res-name", res.Name)
-				return ctrl.Result{}, err
-			}
-		}
-
 		// Update reservation status fields
 		res.Status.Namespace = readyNsName
 		res.Status.Expiration = expirationTS
@@ -223,6 +222,15 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 		if err := r.client.Status().Update(ctx, &res); err != nil {
 			log.Error(err, "cannot update status")
 			return ctrl.Result{}, err
+		}
+
+		// Add finalizer after status is persisted so Status.Namespace is guaranteed to be set
+		if !controllerutil.ContainsFinalizer(&res, capiCleanupFinalizer) {
+			controllerutil.AddFinalizer(&res, capiCleanupFinalizer)
+			if err := r.client.Update(ctx, &res); err != nil {
+				log.Error(err, "could not add CAPI cleanup finalizer", "res-name", res.Name)
+				return ctrl.Result{}, err
+			}
 		}
 
 		duration, err := parseDurationTime(*res.Spec.Duration)
@@ -266,6 +274,16 @@ func (r *NamespaceReservationReconciler) handleCAPICleanup(ctx context.Context, 
 
 	namespace := res.Status.Namespace
 	if namespace == "" {
+		controllerutil.RemoveFinalizer(res, capiCleanupFinalizer)
+		if err := r.client.Update(ctx, res); err != nil {
+			log.Error(err, "could not remove CAPI cleanup finalizer", "res-name", res.Name)
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if time.Since(res.DeletionTimestamp.Time) > capiCleanupTimeout {
+		log.Info("CAPI cleanup timed out, releasing finalizer to unblock deletion", "namespace", namespace, "timeout", capiCleanupTimeout)
 		controllerutil.RemoveFinalizer(res, capiCleanupFinalizer)
 		if err := r.client.Update(ctx, res); err != nil {
 			log.Error(err, "could not remove CAPI cleanup finalizer", "res-name", res.Name)

--- a/controllers/cloud.redhat.com/namespacereservation_controller.go
+++ b/controllers/cloud.redhat.com/namespacereservation_controller.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -53,6 +54,9 @@ type NamespaceReservationReconciler struct {
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=namespacereservations,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=namespacereservations/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=namespacereservations/finalizers,verbs=update
+//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch;delete
+
+const capiCleanupFinalizer = "capi-cleanup.cloud.redhat.com"
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=clowdenvironments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=frontendenvironments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets;events;namespaces;limitranges;resourcequotas,verbs=get;list;watch;create;update;patch;delete
@@ -76,6 +80,11 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 
 		r.log.Error(err, fmt.Sprintf("there was an issue retrieving the reservation object for namespace [%s]", req.Namespace))
 		return ctrl.Result{Requeue: true}, err
+	}
+
+	// Handle deletion: drain CAPI resources before allowing namespace GC
+	if !res.DeletionTimestamp.IsZero() {
+		return r.handleCAPICleanup(ctx, log, &res)
 	}
 
 	if res.Status.Pool == "" {
@@ -187,6 +196,15 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 			return ctrl.Result{Requeue: true}, err
 		}
 
+		// Add finalizer to gate namespace GC on CAPI resource cleanup
+		if !controllerutil.ContainsFinalizer(&res, capiCleanupFinalizer) {
+			controllerutil.AddFinalizer(&res, capiCleanupFinalizer)
+			if err := r.client.Update(ctx, &res); err != nil {
+				log.Error(err, "could not add CAPI cleanup finalizer", "res-name", res.Name)
+				return ctrl.Result{}, err
+			}
+		}
+
 		// Update reservation status fields
 		res.Status.Namespace = readyNsName
 		res.Status.Expiration = expirationTS
@@ -239,6 +257,44 @@ func (r *NamespaceReservationReconciler) SetupWithManager(mgr ctrl.Manager) erro
 			RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](time.Duration(500*time.Millisecond), time.Duration(60*time.Second)),
 		}).
 		Complete(r)
+}
+
+func (r *NamespaceReservationReconciler) handleCAPICleanup(ctx context.Context, log logr.Logger, res *crd.NamespaceReservation) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(res, capiCleanupFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	namespace := res.Status.Namespace
+	if namespace == "" {
+		controllerutil.RemoveFinalizer(res, capiCleanupFinalizer)
+		if err := r.client.Update(ctx, res); err != nil {
+			log.Error(err, "could not remove CAPI cleanup finalizer", "res-name", res.Name)
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("Deleting CAPI resources before releasing namespace", "namespace", namespace)
+
+	remaining, err := helpers.DeleteCAPIResources(ctx, r.client, namespace)
+	if err != nil {
+		log.Error(err, "error deleting CAPI resources", "namespace", namespace)
+		return ctrl.Result{}, err
+	}
+
+	if remaining {
+		log.Info("CAPI resources still present, requeueing", "namespace", namespace)
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	log.Info("All CAPI resources removed, releasing finalizer", "namespace", namespace)
+	controllerutil.RemoveFinalizer(res, capiCleanupFinalizer)
+	if err := r.client.Update(ctx, res); err != nil {
+		log.Error(err, "could not remove CAPI cleanup finalizer", "res-name", res.Name)
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
 }
 
 func (r *NamespaceReservationReconciler) reserveNamespace(ctx context.Context, readyNsName string, res *crd.NamespaceReservation) error {

--- a/controllers/cloud.redhat.com/run.go
+++ b/controllers/cloud.redhat.com/run.go
@@ -18,6 +18,7 @@ import (
 	projectv1 "github.com/openshift/api/project/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	crd "github.com/RedHatInsights/ephemeral-namespace-operator/apis/cloud.redhat.com/v1alpha1"
 )
@@ -34,6 +35,7 @@ func init() {
 	utilruntime.Must(projectv1.AddToScheme(scheme))
 	utilruntime.Must(configv1.AddToScheme(scheme))
 	utilruntime.Must(crd.AddToScheme(scheme))
+	utilruntime.Must(clusterv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/controllers/cloud.redhat.com/suite_test.go
+++ b/controllers/cloud.redhat.com/suite_test.go
@@ -118,6 +118,7 @@ var _ = BeforeSuite(func() {
 	utilruntime.Must(clientgoscheme.AddToScheme(k8sscheme))
 	utilruntime.Must(clowder.AddToScheme(k8sscheme))
 	utilruntime.Must(frontend.AddToScheme(k8sscheme))
+	utilruntime.Must(clusterv1.AddToScheme(k8sscheme))
 
 	err = crd.AddToScheme(k8sscheme)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

- Registers the `cluster-api` v1beta1 scheme so the controller can list and delete `Cluster` resources
- Adds `helpers.DeleteCAPIResources` helper that deletes all `Cluster` objects in a namespace and reports whether any remain
- Adds a `capi-cleanup.cloud.redhat.com` finalizer to `NamespaceReservation` once a namespace is assigned
- On deletion, `handleCAPICleanup` blocks removal and requeues every 10s until all `Cluster` resources are fully gone, then releases the finalizer

**Why**: CAPI controllers need `rosa-creds-secret` to run their own finalizers when a `Cluster` is deleted. If the namespace is GC'd before those finalizers complete, the secret disappears and cleanup stalls/fails. This finalizer ensures CAPI gets a clean window to finish before the namespace is released.

## Test plan

- [ ] Create a reservation in a pool, deploy a CAPI `Cluster` into the reserved namespace
- [ ] Delete the reservation and verify it stays in `Terminating` until the `Cluster` resource is fully removed
- [ ] Verify reservations with no CAPI resources delete immediately without being held by the finalizer
- [ ] Verify reservations with no assigned namespace (empty `Status.Namespace`) skip cleanup and delete cleanly
- [ ] Run `make pre-push` to confirm formatting, vet, and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)