### PR TITLE
fix(rbac): add CAPI cluster RBAC permissions for cleanup finalizer

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -58,6 +58,15 @@ rules:
   - patch
   - update
 - apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - config.openshift.io
   resources:
   - ingresses

--- a/controllers/cloud.redhat.com/namespacepool_controller_suite_test.go
+++ b/controllers/cloud.redhat.com/namespacepool_controller_suite_test.go
@@ -98,9 +98,13 @@ var _ = Describe("Namespace creation should not exceed the pool size limit if on
 			err = k8sClient.Get(ctx, types.NamespacedName{Name: "default"}, &pool)
 			Expect(err).NotTo(HaveOccurred())
 
-			pool.Spec.Size--
+			targetSize := pool.Spec.Size - 1
 
 			Eventually(func() error {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: "default"}, &pool); err != nil {
+					return err
+				}
+				pool.Spec.Size = targetSize
 				return k8sClient.Update(ctx, &pool)
 			}, timeout, interval).Should(BeNil())
 
@@ -112,9 +116,13 @@ var _ = Describe("Namespace creation should not exceed the pool size limit if on
 			}, timeout, interval).Should(Equal(1))
 
 			By("Ensuring that if the limit is increased, more namespaces are created")
-			pool.Spec.Size++
+			targetSize = pool.Spec.Size + 1
 
 			Eventually(func() error {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: "default"}, &pool); err != nil {
+					return err
+				}
+				pool.Spec.Size = targetSize
 				return k8sClient.Update(ctx, &pool)
 			}, timeout, interval).Should(BeNil())
 
@@ -125,9 +133,13 @@ var _ = Describe("Namespace creation should not exceed the pool size limit if on
 				return pool.Spec.Size == pool.Status.Ready
 			}, timeout, interval).Should(BeTrue())
 
-			pool.Spec.Size--
+			targetSize = pool.Spec.Size - 1
 
 			Eventually(func() error {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: "default"}, &pool); err != nil {
+					return err
+				}
+				pool.Spec.Size = targetSize
 				return k8sClient.Update(ctx, &pool)
 			}, timeout, interval).Should(BeNil())
 		})

--- a/deploy.yml
+++ b/deploy.yml
@@ -1875,6 +1875,15 @@ objects:
     - patch
     - update
   - apiGroups:
+    - cluster.x-k8s.io
+    resources:
+    - clusters
+    verbs:
+    - delete
+    - get
+    - list
+    - watch
+  - apiGroups:
     - config.openshift.io
     resources:
     - ingresses


### PR DESCRIPTION
## Summary

- Adds `delete`, `get`, `list`, and `watch` permissions on `cluster.x-k8s.io/clusters` to `config/rbac/role.yaml` and `deploy.yml`
- These permissions are required by the CAPI cleanup finalizer introduced in #572, which deletes CAPI Cluster resources when a NamespaceReservation is cleaned up

## Test plan

- [ ] Verify operator deploys successfully with updated RBAC
- [ ] Confirm CAPI cluster cleanup finalizer can delete clusters without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)