### PR TITLE
Add mintmaker config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		":disableMajorUpdates",
+		":group:kubernetesMonorepo",
+		"github>konflux-ci/mintmaker-presets:cve-automerge-all"
+	],
+	"dockerfile": {
+		"managerFilePatterns": [
+			"/Dockerfile$/",
+			"/Dockerfile-local$/"
+		]
+	},
+	"ignoreDeps": [
+		"sigs.k8s.io/controller-runtime"
+	],
+	"packageRules": [
+		{
+			"matchDatasources": [ "docker" ],
+			"matchPackageNames": [
+				"registry.access.redhat.com/ubi9/go-toolset",
+				"registry.access.redhat.com/ubi9/ubi-minimal"
+			],
+			"versioning": "redhat"
+		}
+	],
+	"postUpdateOptions": [ "gomodTidy" ]
+}


### PR DESCRIPTION
Add mintmaker config file to set custom rules:

- enabling grouping of Kubernetes packages
- set automerge config for CVEs
- disable major updates for packages
- set tag rules for redhat images

When we merge this we can turn on the `mintmaker-automerge` custom property in the repo to allow Konflux to merge without approvals