### PR TITLE
Remove CAPI cleanup timeout to prevent credential secret deletion race

### DIFF
--- a/controllers/cloud.redhat.com/namespacereservation_controller.go
+++ b/controllers/cloud.redhat.com/namespacereservation_controller.go
@@ -52,7 +52,6 @@ type NamespaceReservationReconciler struct {
 }
 
 const capiCleanupFinalizer = "capi-cleanup.cloud.redhat.com"
-const capiCleanupTimeout = 1 * time.Hour
 
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=namespacereservations,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=namespacereservations/status,verbs=get;update;patch
@@ -282,14 +281,12 @@ func (r *NamespaceReservationReconciler) handleCAPICleanup(ctx context.Context, 
 		return ctrl.Result{}, nil
 	}
 
-	if time.Since(res.DeletionTimestamp.Time) > capiCleanupTimeout {
-		log.Info("CAPI cleanup timed out, releasing finalizer to unblock deletion", "namespace", namespace, "timeout", capiCleanupTimeout)
-		controllerutil.RemoveFinalizer(res, capiCleanupFinalizer)
-		if err := r.client.Update(ctx, res); err != nil {
-			log.Error(err, "could not remove CAPI cleanup finalizer", "res-name", res.Name)
+	if res.Status.State != "deleting" {
+		res.Status.State = "deleting"
+		if err := r.client.Status().Update(ctx, res); err != nil {
+			log.Error(err, "could not update reservation state to deleting", "res-name", res.Name)
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, nil
 	}
 
 	log.Info("Deleting CAPI resources before releasing namespace", "namespace", namespace)


### PR DESCRIPTION
## Summary
- Removes the 1-hour timeout from `handleCAPICleanup` that force-released the ENO's finalizer while CAPI resources still had active finalizers
- The timeout caused a race condition: namespace termination deleted `rosa-creds-secret` before the CAPA controller could authenticate to OCM, permanently deadlocking namespaces in `Terminating` state
- The ENO now waits indefinitely for CAPI resources to fully finalize before releasing the namespace
- Sets reservation `Status.State` to `"deleting"` during the CAPI cleanup phase so stuck reservations are easily identifiable via `kubectl get namespacereservation`

## Root cause

When the timeout fired, the ENO released its `capi-cleanup.cloud.redhat.com` finalizer on the NamespaceReservation. This allowed the NR to be fully deleted, which cascade-deleted the namespace. During namespace termination, Kubernetes deleted `rosa-creds-secret` (no finalizer) while the CAPI resources (Cluster, ROSAControlPlane, ROSAMachinePool) still had active finalizers. The CAPA controller then could not authenticate to OCM to confirm cluster deletion, so the finalizers were never removed and the namespace was stuck forever.

## Follow-up

[ENGPROD-9908](https://redhat.atlassian.net/browse/ENGPROD-9908) tracks adding a Prometheus metric (`eno_capi_cleanup_duration_seconds`) to detect namespaces stuck in the CAPI cleanup phase for an extended period.

## Test plan
- [x] All 57 existing unit tests pass
- [ ] Deploy to staging and verify that ROSA namespace teardown completes without deadlock
- [ ] Verify that reservations show `deleting` state during CAPI cleanup
- [ ] Verify that the ENO correctly holds the finalizer until CAPI resources are fully gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENGPROD-9908]: https://redhat.atlassian.net/browse/ENGPROD-9908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ