### PR TITLE
fix: remove stuck ROSAMachinePool finalizers during namespace cleanup

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -67,6 +67,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - rosamachinepools
+  verbs:
+  - get
+  - list
+  - update
+- apiGroups:
   - config.openshift.io
   resources:
   - ingresses

--- a/controllers/cloud.redhat.com/helpers/capi.go
+++ b/controllers/cloud.redhat.com/helpers/capi.go
@@ -6,8 +6,11 @@ import (
 
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // DeleteCAPIResources deletes all Cluster resources in the given namespace and reports whether any remain.
@@ -33,4 +36,41 @@ func DeleteCAPIResources(ctx context.Context, cl client.Client, namespace string
 	}
 
 	return len(clusterList.Items) > 0, nil
+}
+
+// RemoveStuckROSAMachinePoolFinalizers removes the controller finalizer from any ROSAMachinePool
+// resources in the namespace that are stuck in deletion due to a reconciliation failure (e.g. the
+// OCM API rejecting an update with 400). This unblocks the MachinePool → Cluster deletion chain.
+// Returns (false, nil) when the ROSAMachinePool CRD is not installed on the cluster.
+func RemoveStuckROSAMachinePoolFinalizers(ctx context.Context, cl client.Client, namespace string) (bool, error) {
+	const finalizer = "rosamachinepools.infrastructure.cluster.x-k8s.io"
+
+	poolList := &unstructured.UnstructuredList{}
+	poolList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "infrastructure.cluster.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "ROSAMachinePoolList",
+	})
+
+	if err := cl.List(ctx, poolList, client.InNamespace(namespace)); err != nil {
+		if apimeta.IsNoMatchError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("could not list ROSAMachinePool in [%s]: %w", namespace, err)
+	}
+
+	patched := false
+	for i := range poolList.Items {
+		pool := &poolList.Items[i]
+		if pool.GetDeletionTimestamp().IsZero() || !controllerutil.ContainsFinalizer(pool, finalizer) {
+			continue
+		}
+		controllerutil.RemoveFinalizer(pool, finalizer)
+		if err := cl.Update(ctx, pool); err != nil && !k8serr.IsNotFound(err) {
+			return false, fmt.Errorf("could not remove finalizer from ROSAMachinePool [%s/%s]: %w", namespace, pool.GetName(), err)
+		}
+		patched = true
+	}
+
+	return patched, nil
 }

--- a/controllers/cloud.redhat.com/helpers/capi.go
+++ b/controllers/cloud.redhat.com/helpers/capi.go
@@ -3,11 +3,13 @@ package helpers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -38,12 +40,16 @@ func DeleteCAPIResources(ctx context.Context, cl client.Client, namespace string
 	return len(clusterList.Items) > 0, nil
 }
 
-// RemoveStuckROSAMachinePoolFinalizers removes the controller finalizer from any ROSAMachinePool
-// resources in the namespace that are stuck in deletion due to a reconciliation failure (e.g. the
-// OCM API rejecting an update with 400). This unblocks the MachinePool → Cluster deletion chain.
+// RemoveStuckROSAMachinePoolFinalizers removes the controller finalizer from ROSAMachinePool
+// resources that are stuck in deletion due to the OCM API rejecting an update with HTTP 400 for
+// an immutable field (e.g. 'aws_node_pool.root_volume.size' is not allowed), AND whose owning
+// Cluster confirms it is blocked waiting on that MachinePool deletion. Both conditions must hold.
 // Returns (false, nil) when the ROSAMachinePool CRD is not installed on the cluster.
 func RemoveStuckROSAMachinePoolFinalizers(ctx context.Context, cl client.Client, namespace string) (bool, error) {
-	const finalizer = "rosamachinepools.infrastructure.cluster.x-k8s.io"
+	const (
+		finalizer        = "rosamachinepools.infrastructure.cluster.x-k8s.io"
+		clusterNameLabel = "cluster.x-k8s.io/cluster-name"
+	)
 
 	poolList := &unstructured.UnstructuredList{}
 	poolList.SetGroupVersionKind(schema.GroupVersionKind{
@@ -62,9 +68,29 @@ func RemoveStuckROSAMachinePoolFinalizers(ctx context.Context, cl client.Client,
 	patched := false
 	for i := range poolList.Items {
 		pool := &poolList.Items[i]
+
 		if pool.GetDeletionTimestamp().IsZero() || !controllerutil.ContainsFinalizer(pool, finalizer) {
 			continue
 		}
+
+		// Only act when the pool is stuck due to an OCM 400 error on an immutable field.
+		if !rosaPoolHasImmutableFieldError(pool) {
+			continue
+		}
+
+		// Also verify the owning Cluster is blocked specifically on MachinePool deletion.
+		clusterName := pool.GetLabels()[clusterNameLabel]
+		if clusterName == "" {
+			continue
+		}
+		waiting, err := clusterWaitingForWorkersDeletion(ctx, cl, namespace, clusterName)
+		if err != nil {
+			return false, err
+		}
+		if !waiting {
+			continue
+		}
+
 		controllerutil.RemoveFinalizer(pool, finalizer)
 		if err := cl.Update(ctx, pool); err != nil && !k8serr.IsNotFound(err) {
 			return false, fmt.Errorf("could not remove finalizer from ROSAMachinePool [%s/%s]: %w", namespace, pool.GetName(), err)
@@ -73,4 +99,58 @@ func RemoveStuckROSAMachinePoolFinalizers(ctx context.Context, cl client.Client,
 	}
 
 	return patched, nil
+}
+
+// rosaPoolHasImmutableFieldError returns true when the ROSAMachinePool's RosaMachinePoolReady
+// condition shows a ReconciliationFailed caused by the OCM API rejecting the immutable field
+// 'aws_node_pool.root_volume.size' with HTTP 400.
+func rosaPoolHasImmutableFieldError(pool *unstructured.Unstructured) bool {
+	conditions, _, _ := unstructured.NestedSlice(pool.Object, "status", "conditions")
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := cond["type"].(string)
+		condStatus, _ := cond["status"].(string)
+		condReason, _ := cond["reason"].(string)
+		if condType != "RosaMachinePoolReady" || condStatus != "False" || condReason != "ReconciliationFailed" {
+			continue
+		}
+		msg, _ := cond["message"].(string)
+		return strings.Contains(msg, "Attribute 'aws_node_pool.root_volume.size' is not allowed")
+	}
+	return false
+}
+
+// clusterWaitingForWorkersDeletion returns true when the named Cluster's Deleting condition
+// indicates it is blocked waiting for MachinePool deletion to complete.
+func clusterWaitingForWorkersDeletion(ctx context.Context, cl client.Client, namespace, clusterName string) (bool, error) {
+	cluster := &unstructured.Unstructured{}
+	cluster.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "cluster.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "Cluster",
+	})
+	if err := cl.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: namespace}, cluster); err != nil {
+		if k8serr.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("could not get Cluster [%s/%s]: %w", namespace, clusterName, err)
+	}
+
+	conditions, _, _ := unstructured.NestedSlice(cluster.Object, "status", "conditions")
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := cond["type"].(string)
+		condReason, _ := cond["reason"].(string)
+		condStatus, _ := cond["status"].(string)
+		if condType == "Deleting" && condReason == "WaitingForWorkersDeletion" && condStatus == "True" {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/controllers/cloud.redhat.com/namespacereservation_controller.go
+++ b/controllers/cloud.redhat.com/namespacereservation_controller.go
@@ -57,6 +57,7 @@ const capiCleanupFinalizer = "capi-cleanup.cloud.redhat.com"
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=namespacereservations/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=namespacereservations/finalizers,verbs=update
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch;delete
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=rosamachinepools,verbs=get;list;update
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=clowdenvironments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cloud.redhat.com,resources=frontendenvironments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets;events;namespaces;limitranges;resourcequotas,verbs=get;list;watch;create;update;patch;delete
@@ -295,6 +296,15 @@ func (r *NamespaceReservationReconciler) handleCAPICleanup(ctx context.Context, 
 	if err != nil {
 		log.Error(err, "error deleting CAPI resources", "namespace", namespace)
 		return ctrl.Result{}, err
+	}
+
+	patched, err := helpers.RemoveStuckROSAMachinePoolFinalizers(ctx, r.client, namespace)
+	if err != nil {
+		log.Error(err, "error removing stuck ROSAMachinePool finalizers", "namespace", namespace)
+		return ctrl.Result{}, err
+	}
+	if patched {
+		log.Info("Removed stuck ROSAMachinePool finalizers, requeueing", "namespace", namespace)
 	}
 
 	if remaining {


### PR DESCRIPTION
## Summary

- During ROSA HCP cluster deletion, the `ROSAMachinePool` controller can get permanently stuck in a reconcile loop when the OCM API returns a 400 error (e.g. `Attribute 'aws_node_pool.root_volume.size' is not allowed`), preventing its finalizer from being removed
- This blocks the full deletion chain: `ROSAMachinePool → MachinePool → Cluster`, leaving the namespace stuck in `deleting` state indefinitely
- Adds `RemoveStuckROSAMachinePoolFinalizers` to the CAPI cleanup helper, which detects `ROSAMachinePool` resources with a `deletionTimestamp` and a stuck controller finalizer and patches them away on each requeue pass

## Root cause

When a `NamespaceReservation` is deleted, the operator issues a delete on the `Cluster`, which cascades to `MachinePool` and `ROSAMachinePool`. The ROSA infrastructure controller then tries to reconcile the `ROSAMachinePool` (e.g. to drain nodes) before running its cleanup, but if the OCM API rejects the update, the controller error-loops indefinitely and never removes its finalizer — leaving the entire chain frozen.

## Test plan

- [ ] Verify that `go vet ./...` and unit tests pass
- [ ] Deploy to a test environment with a ROSA HCP cluster whose `ROSAMachinePool` has a stuck finalizer and confirm the namespace is released after the next reconcile

🤖 Generated with [Claude Code](https://claude.com/claude-code)