### PR TITLE
fix: remove stuck ROSAMachinePool finalizers when ownership chain is gone

### DIFF
--- a/controllers/cloud.redhat.com/helpers/capi.go
+++ b/controllers/cloud.redhat.com/helpers/capi.go
@@ -124,7 +124,9 @@ func rosaPoolHasImmutableFieldError(pool *unstructured.Unstructured) bool {
 }
 
 // clusterWaitingForWorkersDeletion returns true when the named Cluster's Deleting condition
-// indicates it is blocked waiting for MachinePool deletion to complete.
+// indicates it is blocked waiting for MachinePool deletion to complete, or when the Cluster
+// itself no longer exists (the entire ownership chain above the pool is gone, so no controller
+// will ever reconcile the pool's finalizer away).
 func clusterWaitingForWorkersDeletion(ctx context.Context, cl client.Client, namespace, clusterName string) (bool, error) {
 	cluster := &unstructured.Unstructured{}
 	cluster.SetGroupVersionKind(schema.GroupVersionKind{
@@ -134,7 +136,7 @@ func clusterWaitingForWorkersDeletion(ctx context.Context, cl client.Client, nam
 	})
 	if err := cl.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: namespace}, cluster); err != nil {
 		if k8serr.IsNotFound(err) {
-			return false, nil
+			return true, nil
 		}
 		return false, fmt.Errorf("could not get Cluster [%s/%s]: %w", namespace, clusterName, err)
 	}

--- a/controllers/cloud.redhat.com/helpers/helpers_test.go
+++ b/controllers/cloud.redhat.com/helpers/helpers_test.go
@@ -12,7 +12,9 @@ import (
 	. "github.com/onsi/gomega"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -932,6 +934,147 @@ var _ = Describe("Helper Functions", func() {
 
 			err := CopySecretsFrom(ctx, fakeClient, "empty-base", "target-ns", false)
 			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("RemoveStuckROSAMachinePoolFinalizers", func() {
+		const (
+			testNamespace = "test-ns"
+			clusterName   = "test-cluster"
+			poolFinalizer = "rosamachinepools.infrastructure.cluster.x-k8s.io"
+		)
+
+		var rosaScheme *runtime.Scheme
+
+		BeforeEach(func() {
+			rosaScheme = runtime.NewScheme()
+			Expect(core.AddToScheme(rosaScheme)).To(Succeed())
+			Expect(clusterv1.AddToScheme(rosaScheme)).To(Succeed())
+			rosaScheme.AddKnownTypeWithName(
+				schema.GroupVersionKind{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta2", Kind: "ROSAMachinePool"},
+				&unstructured.Unstructured{},
+			)
+			rosaScheme.AddKnownTypeWithName(
+				schema.GroupVersionKind{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta2", Kind: "ROSAMachinePoolList"},
+				&unstructured.UnstructuredList{},
+			)
+			rosaScheme.AddKnownTypeWithName(
+				schema.GroupVersionKind{Group: "cluster.x-k8s.io", Version: "v1beta2", Kind: "Cluster"},
+				&unstructured.Unstructured{},
+			)
+		})
+
+		// makePool builds an unstructured ROSAMachinePool with a deletionTimestamp, the CAPA
+		// finalizer, and a dummy extra finalizer (so the object is not GC'd when we remove the
+		// real one, allowing us to assert on the resulting finalizer list).
+		makePool := func(withImmutableError bool) *unstructured.Unstructured {
+			now := metav1.Now()
+			pool := &unstructured.Unstructured{}
+			pool.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "infrastructure.cluster.x-k8s.io",
+				Version: "v1beta2",
+				Kind:    "ROSAMachinePool",
+			})
+			pool.SetName("workers")
+			pool.SetNamespace(testNamespace)
+			pool.SetLabels(map[string]string{"cluster.x-k8s.io/cluster-name": clusterName})
+			pool.SetDeletionTimestamp(&now)
+			pool.SetFinalizers([]string{poolFinalizer, "dummy-finalizer"})
+
+			if withImmutableError {
+				Expect(unstructured.SetNestedSlice(pool.Object, []interface{}{
+					map[string]interface{}{
+						"type":    "RosaMachinePoolReady",
+						"status":  "False",
+						"reason":  "ReconciliationFailed",
+						"message": "Attribute 'aws_node_pool.root_volume.size' is not allowed",
+					},
+				}, "status", "conditions")).To(Succeed())
+			}
+			return pool
+		}
+
+		makeCluster := func(deletingReason string) *unstructured.Unstructured {
+			cluster := &unstructured.Unstructured{}
+			cluster.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "cluster.x-k8s.io",
+				Version: "v1beta2",
+				Kind:    "Cluster",
+			})
+			cluster.SetName(clusterName)
+			cluster.SetNamespace(testNamespace)
+			if deletingReason != "" {
+				Expect(unstructured.SetNestedSlice(cluster.Object, []interface{}{
+					map[string]interface{}{
+						"type":   "Deleting",
+						"reason": deletingReason,
+						"status": "True",
+					},
+				}, "status", "conditions")).To(Succeed())
+			}
+			return cluster
+		}
+
+		It("should remove finalizer when cluster is gone and pool has immutable field error", func() {
+			pool := makePool(true)
+			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool).Build()
+
+			patched, err := RemoveStuckROSAMachinePoolFinalizers(ctx, c, testNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(patched).To(BeTrue())
+
+			fetched := &unstructured.Unstructured{}
+			fetched.SetGroupVersionKind(pool.GroupVersionKind())
+			Expect(c.Get(ctx, types.NamespacedName{Name: "workers", Namespace: testNamespace}, fetched)).To(Succeed())
+			Expect(fetched.GetFinalizers()).To(ConsistOf("dummy-finalizer"))
+		})
+
+		It("should remove finalizer when cluster is WaitingForWorkersDeletion", func() {
+			pool := makePool(true)
+			cluster := makeCluster("WaitingForWorkersDeletion")
+			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool, cluster).Build()
+
+			patched, err := RemoveStuckROSAMachinePoolFinalizers(ctx, c, testNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(patched).To(BeTrue())
+
+			fetched := &unstructured.Unstructured{}
+			fetched.SetGroupVersionKind(pool.GroupVersionKind())
+			Expect(c.Get(ctx, types.NamespacedName{Name: "workers", Namespace: testNamespace}, fetched)).To(Succeed())
+			Expect(fetched.GetFinalizers()).To(ConsistOf("dummy-finalizer"))
+		})
+
+		It("should not remove finalizer when cluster exists but is not WaitingForWorkersDeletion", func() {
+			pool := makePool(true)
+			cluster := makeCluster("WaitingForControlPlaneDeletion")
+			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool, cluster).Build()
+
+			patched, err := RemoveStuckROSAMachinePoolFinalizers(ctx, c, testNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(patched).To(BeFalse())
+
+			fetched := &unstructured.Unstructured{}
+			fetched.SetGroupVersionKind(pool.GroupVersionKind())
+			Expect(c.Get(ctx, types.NamespacedName{Name: "workers", Namespace: testNamespace}, fetched)).To(Succeed())
+			Expect(fetched.GetFinalizers()).To(ConsistOf(poolFinalizer, "dummy-finalizer"))
+		})
+
+		It("should not remove finalizer when pool lacks the immutable field error", func() {
+			pool := makePool(false)
+			cluster := makeCluster("WaitingForWorkersDeletion")
+			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool, cluster).Build()
+
+			patched, err := RemoveStuckROSAMachinePoolFinalizers(ctx, c, testNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(patched).To(BeFalse())
+		})
+
+		It("should return false when no ROSAMachinePool resources exist", func() {
+			c := fake.NewClientBuilder().WithScheme(rosaScheme).Build()
+
+			patched, err := RemoveStuckROSAMachinePoolFinalizers(ctx, c, testNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(patched).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
## Summary

- Fixes a case where a \`ROSAMachinePool\` stuck with the immutable-field OCM 400 error would never have its finalizer removed because its owning \`MachinePool\` and \`Cluster\` had already been deleted
- The CAPA controller errors with \"owner MachinePool not found\" in this state and cannot reconcile the finalizer away on its own (seen in \`ephemeral-etyben\`)
- \`clusterWaitingForWorkersDeletion\` now returns \`true\` when the Cluster is not found — an absent ownership chain is an even stronger signal than \`WaitingForWorkersDeletion\` that no controller will ever clean up the pool

## Test plan

- [ ] 5 new unit tests added to \`helpers_test.go\` covering: cluster gone (new case), cluster \`WaitingForWorkersDeletion\` (existing case), cluster with wrong reason (negative), pool without the immutable error (negative), no pools in namespace (no-op)
- [ ] \`make pre-push\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)