### PR TITLE
ENO Kuttl Tests in Codebuild

### DIFF
--- a/.github/workflows/pr-e2e-codebuild.yml
+++ b/.github/workflows/pr-e2e-codebuild.yml
@@ -1,0 +1,223 @@
+name: PR E2E Tests (CodeBuild)
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  trigger-codebuild:
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/test-e2e')
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check user permissions
+        id: check-permissions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const username = context.payload.comment.user.login;
+
+            try {
+              const { data: permissionData } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: username
+              });
+
+              const permission = permissionData.permission;
+              console.log(`User ${username} has permission: ${permission}`);
+
+              const allowedPermissions = ['admin', 'write', 'maintain'];
+
+              if (!allowedPermissions.includes(permission)) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: `@${username} Sorry, you don't have permission to trigger E2E tests. This command is restricted to repository maintainers.`
+                });
+
+                core.setFailed(`User ${username} does not have sufficient permissions (has: ${permission}, needs: ${allowedPermissions.join(', ')})`);
+              }
+
+              core.setOutput('allowed', 'true');
+            } catch (error) {
+              console.error('Error checking permissions:', error);
+              core.setFailed('Failed to check user permissions');
+            }
+
+      - name: React to comment
+        if: steps.check-permissions.outputs.allowed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            });
+
+      - name: Get PR details
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('sha', pr.data.head.sha);
+            core.setOutput('ref', pr.data.head.ref);
+            core.setOutput('repo', pr.data.head.repo.clone_url);
+
+      - name: Check if PR has buildspec.yml
+        id: check-buildspec
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: 'buildspec.yml',
+                ref: '${{ steps.pr.outputs.sha }}'
+              });
+              core.setOutput('has-buildspec', 'true');
+            } catch (error) {
+              if (error.status === 404) {
+                core.setOutput('has-buildspec', 'false');
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: '⚠️ This PR branch does not contain `buildspec.yml`, which is required to run E2E tests.\n\nPlease rebase this PR with the `main` branch to include the latest changes, then try `/test-e2e` again.'
+                });
+              } else {
+                throw error;
+              }
+            }
+
+      - name: Fail if buildspec.yml is missing
+        if: steps.check-buildspec.outputs.has-buildspec == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = '${{ steps.pr.outputs.sha }}';
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: sha,
+              state: 'failure',
+              context: 'CodeBuild / E2E Tests',
+              description: 'PR needs rebase - buildspec.yml missing'
+            });
+
+            core.setFailed('This PR branch does not contain buildspec.yml. Please rebase with main.');
+
+      - name: Create pending status check
+        if: steps.check-permissions.outputs.allowed == 'true' && steps.check-buildspec.outputs.has-buildspec == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const projectUrl = 'https://us-east-1.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiMVJ6blhZVWU3d2llUTBEdG1UbTFRNXRkdEk4TGVUQzZlNFQ2c0JJaUl5THZNdkU2OWVmTk93emJXRnVreG12b1FUTld5cW1OaWk2UWhaSk5Bcm91UGlTSmx5ajZZWkJUcmVVdUsxND0iLCJpdlBhcmFtZXRlclNwZWMiOiJWRG9FVVBNeGVaa1YxN2pxIiwibWF0ZXJpYWxTZXRTZXJpYWwiOjF9';
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ steps.pr.outputs.sha }}',
+              state: 'pending',
+              context: 'CodeBuild / E2E Tests',
+              description: 'Running E2E tests...',
+              target_url: projectUrl
+            });
+
+      - name: Configure AWS credentials
+        if: steps.check-buildspec.outputs.has-buildspec == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Run CodeBuild
+        if: steps.check-buildspec.outputs.has-buildspec == 'true'
+        id: codebuild
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          hide-cloudwatch-logs: true
+          project-name: eno-pr-check
+          source-version-override: ${{ steps.pr.outputs.sha }}
+          env-vars-for-codebuild: |
+            GITHUB_PR_NUMBER,
+            GITHUB_SHA,
+            GITHUB_REF,
+            GITHUB_ACTOR,
+            GITHUB_REPOSITORY
+        env:
+          GITHUB_PR_NUMBER: ${{ github.event.issue.number }}
+          GITHUB_SHA: ${{ steps.pr.outputs.sha }}
+          GITHUB_REF: ${{ steps.pr.outputs.ref }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+
+      - name: Update status check on success
+        if: success() && steps.codebuild.outputs.aws-build-id
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const buildId = '${{ steps.codebuild.outputs.aws-build-id }}'.split(':')[1];
+            const buildUrl = `https://us-east-1.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiMVJ6blhZVWU3d2llUTBEdG1UbTFRNXRkdEk4TGVUQzZlNFQ2c0JJaUl5THZNdkU2OWVmTk93emJXRnVreG12b1FUTld5cW1OaWk2UWhaSk5Bcm91UGlTSmx5ajZZWkJUcmVVdUsxND0iLCJpdlBhcmFtZXRlclNwZWMiOiJWRG9FVVBNeGVaa1YxN2pxIiwibWF0ZXJpYWxTZXRTZXJpYWwiOjF9/build/${buildId}`;
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ steps.pr.outputs.sha }}',
+              state: 'success',
+              context: 'CodeBuild / E2E Tests',
+              description: 'E2E tests passed',
+              target_url: buildUrl
+            });
+
+      - name: Update status check on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const buildId = '${{ steps.codebuild.outputs.aws-build-id }}';
+            const baseUrl = 'https://us-east-1.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiMVJ6blhZVWU3d2llUTBEdG1UbTFRNXRkdEk4TGVUQzZlNFQ2c0JJaUl5THZNdkU2OWVmTk93emJXRnVreG12b1FUTld5cW1OaWk2UWhaSk5Bcm91UGlTSmx5ajZZWkJUcmVVdUsxND0iLCJpdlBhcmFtZXRlclNwZWMiOiJWRG9FVVBNeGVaa1YxN2pxIiwibWF0ZXJpYWxTZXRTZXJpYWwiOjF9';
+
+            let buildUrl;
+            let description;
+
+            if (buildId) {
+              buildUrl = `${baseUrl}/build/${buildId.split(':')[1]}`;
+              description = 'E2E tests failed';
+            } else {
+              buildUrl = baseUrl;
+              description = 'Failed to start E2E tests';
+            }
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ steps.pr.outputs.sha }}',
+              state: 'failure',
+              context: 'CodeBuild / E2E Tests',
+              description: description,
+              target_url: buildUrl
+            });

--- a/build/buildspec_steps/build_eno.sh
+++ b/build/buildspec_steps/build_eno.sh
@@ -1,0 +1,13 @@
+set -e
+
+echo "Building ENO image locally..."
+
+export PATH="/usr/local/go/bin:$PATH"
+
+export IMAGE_TAG=$(git rev-parse --short=8 HEAD)
+export IMG="ephemeral-namespace-operator:${IMAGE_TAG}"
+docker build -t ${IMG} .
+kind load docker-image ${IMG} --name ${CLUSTER_NAME}
+
+echo "Generating manifest with local image ${IMG}..."
+make release

--- a/build/buildspec_steps/create_kind_cluster.sh
+++ b/build/buildspec_steps/create_kind_cluster.sh
@@ -1,0 +1,20 @@
+set -e
+
+echo "Creating kind cluster ${CLUSTER_NAME} using ${KINDEST_NODE_IMAGE}..."
+
+cat > kind.yaml <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        enable-admission-plugins: ValidatingAdmissionWebhook,MutatingAdmissionWebhook
+EOF
+
+kind create cluster --name "${CLUSTER_NAME}" --image "${KINDEST_NODE_IMAGE}" --config kind.yaml --wait 180s
+kubectl cluster-info
+kubectl get nodes -o wide

--- a/build/buildspec_steps/deploy_eno.sh
+++ b/build/buildspec_steps/deploy_eno.sh
@@ -1,0 +1,26 @@
+set -e
+
+ENO_NAMESPACE="ephemeral-namespace-operator-system"
+
+echo "Deploying ENO operator..."
+kubectl create namespace ${ENO_NAMESPACE} || true
+kubectl apply -f manifest.yaml --validate=false -n ${ENO_NAMESPACE}
+
+echo "=== Debugging ENO deployment ==="
+sleep 10
+kubectl get pods -n ${ENO_NAMESPACE} -o wide
+kubectl get deployment -n ${ENO_NAMESPACE}
+kubectl describe deployment ephemeral-namespace-operator-controller-manager -n ${ENO_NAMESPACE} || true
+kubectl get events -n ${ENO_NAMESPACE} --sort-by='.lastTimestamp' | tail -20 || true
+
+ENO_POD=$(kubectl get pod -n ${ENO_NAMESPACE} -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+if [ -n "$ENO_POD" ]; then
+    echo "=== ENO pod found: $ENO_POD ==="
+    kubectl describe pod "$ENO_POD" -n ${ENO_NAMESPACE} || true
+    kubectl logs "$ENO_POD" -n ${ENO_NAMESPACE} --tail=50 || true
+else
+    echo "=== No ENO pod found yet ==="
+fi
+
+echo "=== Starting rollout wait ==="
+kubectl rollout status deployment/ephemeral-namespace-operator-controller-manager -n ${ENO_NAMESPACE} --timeout=600s

--- a/build/buildspec_steps/install_dependencies.sh
+++ b/build/buildspec_steps/install_dependencies.sh
@@ -1,0 +1,31 @@
+set -e
+
+if [ -n "${GITHUB_PR_NUMBER}" ]; then
+    echo "=========================================="
+    echo "Running E2E tests for PR #${GITHUB_PR_NUMBER}"
+    echo "Commit: ${GITHUB_SHA}"
+    echo "Branch: ${GITHUB_REF}"
+    echo "Triggered by: ${GITHUB_ACTOR}"
+    echo "Repository: ${GITHUB_REPOSITORY}"
+    echo "=========================================="
+fi
+
+echo "Installing Go 1.25.7..."
+rm -rf /usr/local/go
+curl -fsSL https://go.dev/dl/go1.25.7.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+export PATH="/usr/local/go/bin:$PATH"
+go version
+
+echo "Installing base tools (jq, git, make, tar, unzip)..."
+yum -y install jq git make tar unzip >/dev/null 2>&1 || true
+
+echo "Installing kind, kubectl, and kuttl..."
+curl -fsSL -o /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
+chmod +x /usr/local/bin/kind
+curl -fsSL -o /usr/local/bin/kubectl https://dl.k8s.io/release/${K8S_VERSION}/bin/linux/amd64/kubectl
+chmod +x /usr/local/bin/kubectl
+
+echo "Installing kubectl-kuttl from GitHub releases..."
+curl -fsSL https://github.com/kudobuilder/kuttl/releases/download/v${KUTTL_VERSION}/kubectl-kuttl_${KUTTL_VERSION}_linux_x86_64 -o /usr/local/bin/kubectl-kuttl
+chmod +x /usr/local/bin/kubectl-kuttl
+kubectl-kuttl version

--- a/build/buildspec_steps/install_operators.sh
+++ b/build/buildspec_steps/install_operators.sh
@@ -1,0 +1,7 @@
+set -e
+
+echo "Installing static CRDs (ClowdEnvironment, FrontendEnvironment)..."
+kubectl apply -f config/crd/static/
+
+echo "Installed CRDs:"
+kubectl get crds | grep cloud.redhat.com || true

--- a/build/buildspec_steps/run_kuttl_tests.sh
+++ b/build/buildspec_steps/run_kuttl_tests.sh
@@ -1,0 +1,20 @@
+set -e
+
+ENO_NAMESPACE="ephemeral-namespace-operator-system"
+
+echo "Running KUTTL tests..."
+set +e
+bash build/run_kuttl.sh --report xml
+TEST_RC=$?
+set -e
+mv "${ARTIFACTS_DIR}/kuttl-report.xml" "${ARTIFACTS_DIR}/junit-kuttl.xml" || true
+
+echo "Collecting logs and metrics..."
+for p in $(kubectl get pod -n ${ENO_NAMESPACE} -o jsonpath='{.items[*].metadata.name}'); do
+    kubectl logs "$p" -n ${ENO_NAMESPACE} > "${ARTIFACTS_DIR}/${p}.log" || true
+    kubectl logs "$p" -n ${ENO_NAMESPACE} --previous=true > "${ARTIFACTS_DIR}/${p}-previous.log" || true
+done
+kubectl -n ${ENO_NAMESPACE} get all -o wide > "${ARTIFACTS_DIR}/eno-system-get-all.txt" || true
+kubectl get events --all-namespaces --sort-by=.lastTimestamp > "${ARTIFACTS_DIR}/cluster-events.txt" || true
+
+exit "$TEST_RC"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,38 @@
+version: 0.2
+
+env:
+  variables:
+    CLUSTER_NAME: eno-e2e
+    K8S_VERSION: v1.29.4
+    KINDEST_NODE_IMAGE: kindest/node:v1.29.4
+    KUTTL_VERSION: "0.19.0"
+    ARTIFACTS_DIR: /tmp/artifacts
+    CODEBUILD_BUILD_TIMEOUT: 60
+
+phases:
+  install:
+    commands:
+      - bash build/buildspec_steps/install_dependencies.sh
+      - mkdir -p "${ARTIFACTS_DIR}"
+
+  pre_build:
+    commands:
+      - bash build/buildspec_steps/create_kind_cluster.sh
+
+  build:
+    commands:
+      - bash build/buildspec_steps/install_operators.sh
+      - bash build/buildspec_steps/build_eno.sh
+      - bash build/buildspec_steps/deploy_eno.sh
+      - bash build/buildspec_steps/run_kuttl_tests.sh
+
+  post_build:
+    commands:
+      - echo "Deleting kind cluster ${CLUSTER_NAME}..."
+      - kind delete cluster --name "${CLUSTER_NAME}" || true
+
+artifacts:
+  files:
+    - ${ARTIFACTS_DIR}/**/*
+  discard-paths: no
+  name: eno-e2e-pr-${GITHUB_PR_NUMBER:-manual}-${GITHUB_SHA:-$CODEBUILD_RESOLVED_SOURCE_VERSION}

--- a/tests/kuttl/test-multiple-pools/00-assert.yaml
+++ b/tests/kuttl/test-multiple-pools/00-assert.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: pool-alpha
+status:
+  ready: 1
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: pool-beta
+status:
+  ready: 1

--- a/tests/kuttl/test-multiple-pools/00-install.yaml
+++ b/tests/kuttl/test-multiple-pools/00-install.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ephemeral-base
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: pool-alpha
+spec:
+  size: 1
+  sizeLimit: 1
+  local: true
+  limitrange:
+    metadata:
+      name: resource-limits
+    spec:
+      limits:
+      - type: Container
+        default:
+          cpu: 200m
+          memory: 512Mi
+        defaultRequest:
+          cpu: 100m
+          memory: 384Mi
+  resourcequotas:
+    items:
+    - metadata:
+        name: compute-resources
+      spec:
+        hard:
+          pods: "10"
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: pool-beta
+spec:
+  size: 1
+  local: true
+  limitrange:
+    metadata:
+      name: resource-limits
+    spec:
+      limits:
+      - type: Container
+        default:
+          cpu: 200m
+          memory: 512Mi
+        defaultRequest:
+          cpu: 100m
+          memory: 384Mi
+  resourcequotas:
+    items:
+    - metadata:
+        name: compute-resources
+      spec:
+        hard:
+          pods: "10"

--- a/tests/kuttl/test-multiple-pools/01-assert.yaml
+++ b/tests/kuttl/test-multiple-pools/01-assert.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: test-multi-pool-res
+status:
+  state: active
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: pool-alpha
+status:
+  ready: 0
+  reserved: 1
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: pool-beta
+status:
+  ready: 1

--- a/tests/kuttl/test-multiple-pools/01-install.yaml
+++ b/tests/kuttl/test-multiple-pools/01-install.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: test-multi-pool-res
+spec:
+  requester: kuttl-test
+  duration: "1h"
+  pool: pool-alpha

--- a/tests/kuttl/test-multiple-pools/02-check-pool.sh
+++ b/tests/kuttl/test-multiple-pools/02-check-pool.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+RESERVATION_NAME="test-multi-pool-res"
+
+NS=$(kubectl get namespacereservation "${RESERVATION_NAME}" -o jsonpath='{.status.namespace}')
+
+if [ -z "${NS}" ]; then
+  echo "ERROR: Reservation ${RESERVATION_NAME} has no namespace assigned"
+  exit 1
+fi
+
+echo "Reservation assigned namespace: ${NS}"
+
+# Verify namespace belongs to pool-alpha (not pool-beta)
+POOL_LABEL=$(kubectl get namespace "${NS}" -o jsonpath='{.metadata.labels.pool}')
+if [ "${POOL_LABEL}" != "pool-alpha" ]; then
+  echo "ERROR: Namespace pool label is '${POOL_LABEL}', expected 'pool-alpha'"
+  exit 1
+fi
+echo "PASS: Namespace ${NS} belongs to pool-alpha"
+
+# Verify reservation status shows correct pool
+RES_POOL=$(kubectl get namespacereservation "${RESERVATION_NAME}" -o jsonpath='{.status.pool}')
+if [ "${RES_POOL}" != "pool-alpha" ]; then
+  echo "ERROR: Reservation status pool is '${RES_POOL}', expected 'pool-alpha'"
+  exit 1
+fi
+echo "PASS: Reservation status correctly shows pool-alpha"
+
+echo "SUCCESS: Reservation correctly assigned to pool-alpha"

--- a/tests/kuttl/test-multiple-pools/02-check-pool.yaml
+++ b/tests/kuttl/test-multiple-pools/02-check-pool.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: bash 02-check-pool.sh

--- a/tests/kuttl/test-multiple-pools/03-delete.yaml
+++ b/tests/kuttl/test-multiple-pools/03-delete.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: NamespaceReservation
+  name: test-multi-pool-res
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: NamespacePool
+  name: pool-alpha
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: NamespacePool
+  name: pool-beta

--- a/tests/kuttl/test-pool-scaling/00-assert.yaml
+++ b/tests/kuttl/test-pool-scaling/00-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: test-pool-scaling
+status:
+  ready: 3

--- a/tests/kuttl/test-pool-scaling/00-install.yaml
+++ b/tests/kuttl/test-pool-scaling/00-install.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ephemeral-base
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: test-pool-scaling
+spec:
+  size: 3
+  local: true
+  limitrange:
+    metadata:
+      name: resource-limits
+    spec:
+      limits:
+      - type: Container
+        default:
+          cpu: 200m
+          memory: 512Mi
+        defaultRequest:
+          cpu: 100m
+          memory: 384Mi
+  resourcequotas:
+    items:
+    - metadata:
+        name: compute-resources
+      spec:
+        hard:
+          pods: "10"

--- a/tests/kuttl/test-pool-scaling/01-assert.yaml
+++ b/tests/kuttl/test-pool-scaling/01-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: test-pool-scaling
+status:
+  ready: 1

--- a/tests/kuttl/test-pool-scaling/01-install.yaml
+++ b/tests/kuttl/test-pool-scaling/01-install.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: test-pool-scaling
+spec:
+  size: 1
+  local: true
+  limitrange:
+    metadata:
+      name: resource-limits
+    spec:
+      limits:
+      - type: Container
+        default:
+          cpu: 200m
+          memory: 512Mi
+        defaultRequest:
+          cpu: 100m
+          memory: 384Mi
+  resourcequotas:
+    items:
+    - metadata:
+        name: compute-resources
+      spec:
+        hard:
+          pods: "10"

--- a/tests/kuttl/test-pool-scaling/02-delete.yaml
+++ b/tests/kuttl/test-pool-scaling/02-delete.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: NamespacePool
+  name: test-pool-scaling

--- a/tests/kuttl/test-pool-status/00-assert.yaml
+++ b/tests/kuttl/test-pool-status/00-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: test-pool-status
+status:
+  ready: 2

--- a/tests/kuttl/test-pool-status/00-install.yaml
+++ b/tests/kuttl/test-pool-status/00-install.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ephemeral-base
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: test-pool-status
+spec:
+  size: 2
+  sizeLimit: 2
+  local: true
+  limitrange:
+    metadata:
+      name: resource-limits
+    spec:
+      limits:
+      - type: Container
+        default:
+          cpu: 200m
+          memory: 512Mi
+        defaultRequest:
+          cpu: 100m
+          memory: 384Mi
+  resourcequotas:
+    items:
+    - metadata:
+        name: compute-resources
+      spec:
+        hard:
+          pods: "10"

--- a/tests/kuttl/test-pool-status/01-assert.yaml
+++ b/tests/kuttl/test-pool-status/01-assert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: test-status-res-1
+status:
+  state: active
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: test-pool-status
+status:
+  ready: 1
+  reserved: 1

--- a/tests/kuttl/test-pool-status/01-install.yaml
+++ b/tests/kuttl/test-pool-status/01-install.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: test-status-res-1
+spec:
+  requester: kuttl-test
+  duration: "1h"
+  pool: test-pool-status

--- a/tests/kuttl/test-pool-status/02-assert.yaml
+++ b/tests/kuttl/test-pool-status/02-assert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: test-status-res-2
+status:
+  state: active
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: test-pool-status
+status:
+  ready: 0
+  reserved: 2

--- a/tests/kuttl/test-pool-status/02-install.yaml
+++ b/tests/kuttl/test-pool-status/02-install.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: test-status-res-2
+spec:
+  requester: kuttl-test
+  duration: "1h"
+  pool: test-pool-status

--- a/tests/kuttl/test-pool-status/03-delete.yaml
+++ b/tests/kuttl/test-pool-status/03-delete.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: NamespaceReservation
+  name: test-status-res-1
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: NamespaceReservation
+  name: test-status-res-2
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: NamespacePool
+  name: test-pool-status

--- a/tests/kuttl/test-reservation-default-pool/00-assert.yaml
+++ b/tests/kuttl/test-reservation-default-pool/00-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: default
+status:
+  ready: 1

--- a/tests/kuttl/test-reservation-default-pool/00-install.yaml
+++ b/tests/kuttl/test-reservation-default-pool/00-install.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ephemeral-base
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: default
+spec:
+  size: 1
+  sizeLimit: 1
+  local: true
+  limitrange:
+    metadata:
+      name: resource-limits
+    spec:
+      limits:
+      - type: Container
+        default:
+          cpu: 200m
+          memory: 512Mi
+        defaultRequest:
+          cpu: 100m
+          memory: 384Mi
+  resourcequotas:
+    items:
+    - metadata:
+        name: compute-resources
+      spec:
+        hard:
+          pods: "10"

--- a/tests/kuttl/test-reservation-default-pool/01-assert.yaml
+++ b/tests/kuttl/test-reservation-default-pool/01-assert.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: test-res-default-pool
+status:
+  state: active
+  pool: default

--- a/tests/kuttl/test-reservation-default-pool/01-install.yaml
+++ b/tests/kuttl/test-reservation-default-pool/01-install.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: test-res-default-pool
+spec:
+  requester: kuttl-test
+  duration: "1h"

--- a/tests/kuttl/test-reservation-default-pool/02-check-default.sh
+++ b/tests/kuttl/test-reservation-default-pool/02-check-default.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+RESERVATION_NAME="test-res-default-pool"
+
+# Verify reservation got assigned a namespace
+NS=$(kubectl get namespacereservation "${RESERVATION_NAME}" -o jsonpath='{.status.namespace}')
+if [ -z "${NS}" ]; then
+  echo "ERROR: Reservation has no namespace assigned"
+  exit 1
+fi
+echo "PASS: Reservation assigned namespace: ${NS}"
+
+# Verify the status pool was set to "default"
+POOL=$(kubectl get namespacereservation "${RESERVATION_NAME}" -o jsonpath='{.status.pool}')
+if [ "${POOL}" != "default" ]; then
+  echo "ERROR: Reservation pool is '${POOL}', expected 'default'"
+  exit 1
+fi
+echo "PASS: Reservation defaulted to 'default' pool"
+
+# Verify the namespace has the correct pool label
+NS_POOL=$(kubectl get namespace "${NS}" -o jsonpath='{.metadata.labels.pool}')
+if [ "${NS_POOL}" != "default" ]; then
+  echo "ERROR: Namespace pool label is '${NS_POOL}', expected 'default'"
+  exit 1
+fi
+echo "PASS: Namespace has pool=default label"
+
+echo "SUCCESS: Reservation correctly defaulted to 'default' pool"

--- a/tests/kuttl/test-reservation-default-pool/02-check-default.yaml
+++ b/tests/kuttl/test-reservation-default-pool/02-check-default.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: bash 02-check-default.sh

--- a/tests/kuttl/test-reservation-default-pool/03-delete.yaml
+++ b/tests/kuttl/test-reservation-default-pool/03-delete.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: NamespaceReservation
+  name: test-res-default-pool
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: NamespacePool
+  name: default

--- a/tests/kuttl/test-reservation-exhausted-pool/00-assert.yaml
+++ b/tests/kuttl/test-reservation-exhausted-pool/00-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: test-exhausted-pool
+status:
+  ready: 1

--- a/tests/kuttl/test-reservation-exhausted-pool/00-install.yaml
+++ b/tests/kuttl/test-reservation-exhausted-pool/00-install.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ephemeral-base
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: test-exhausted-pool
+spec:
+  size: 1
+  sizeLimit: 1
+  local: true
+  limitrange:
+    metadata:
+      name: resource-limits
+    spec:
+      limits:
+      - type: Container
+        default:
+          cpu: 200m
+          memory: 512Mi
+        defaultRequest:
+          cpu: 100m
+          memory: 384Mi
+  resourcequotas:
+    items:
+    - metadata:
+        name: compute-resources
+      spec:
+        hard:
+          pods: "10"

--- a/tests/kuttl/test-reservation-exhausted-pool/01-assert.yaml
+++ b/tests/kuttl/test-reservation-exhausted-pool/01-assert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: test-exhaust-res-1
+status:
+  state: active
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: test-exhausted-pool
+status:
+  ready: 0
+  reserved: 1

--- a/tests/kuttl/test-reservation-exhausted-pool/01-install.yaml
+++ b/tests/kuttl/test-reservation-exhausted-pool/01-install.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: test-exhaust-res-1
+spec:
+  requester: kuttl-test
+  duration: "1h"
+  pool: test-exhausted-pool

--- a/tests/kuttl/test-reservation-exhausted-pool/02-assert.yaml
+++ b/tests/kuttl/test-reservation-exhausted-pool/02-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: test-exhaust-res-2
+status:
+  state: waiting

--- a/tests/kuttl/test-reservation-exhausted-pool/02-install.yaml
+++ b/tests/kuttl/test-reservation-exhausted-pool/02-install.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: test-exhaust-res-2
+spec:
+  requester: kuttl-test
+  duration: "1h"
+  pool: test-exhausted-pool

--- a/tests/kuttl/test-reservation-exhausted-pool/03-check-waiting.sh
+++ b/tests/kuttl/test-reservation-exhausted-pool/03-check-waiting.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+# Verify second reservation has no namespace assigned
+NS=$(kubectl get namespacereservation test-exhaust-res-2 -o jsonpath='{.status.namespace}')
+
+if [ -n "${NS}" ]; then
+  echo "ERROR: Second reservation should not have a namespace, but got: ${NS}"
+  exit 1
+fi
+echo "PASS: Second reservation has no namespace assigned"
+
+# Verify first reservation still has its namespace
+NS1=$(kubectl get namespacereservation test-exhaust-res-1 -o jsonpath='{.status.namespace}')
+if [ -z "${NS1}" ]; then
+  echo "ERROR: First reservation should still have a namespace"
+  exit 1
+fi
+echo "PASS: First reservation still holds namespace ${NS1}"
+
+# Verify pool status
+POOL_READY=$(kubectl get namespacepool test-exhausted-pool -o jsonpath='{.status.ready}')
+POOL_RESERVED=$(kubectl get namespacepool test-exhausted-pool -o jsonpath='{.status.reserved}')
+if [ "${POOL_READY}" != "0" ]; then
+  echo "ERROR: Pool ready is ${POOL_READY}, expected 0"
+  exit 1
+fi
+if [ "${POOL_RESERVED}" != "1" ]; then
+  echo "ERROR: Pool reserved is ${POOL_RESERVED}, expected 1"
+  exit 1
+fi
+echo "PASS: Pool correctly shows ready=0, reserved=1 (exhausted)"
+
+echo "SUCCESS: Exhausted pool correctly blocks second reservation"

--- a/tests/kuttl/test-reservation-exhausted-pool/03-check-waiting.yaml
+++ b/tests/kuttl/test-reservation-exhausted-pool/03-check-waiting.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: bash 03-check-waiting.sh

--- a/tests/kuttl/test-reservation-exhausted-pool/04-delete.yaml
+++ b/tests/kuttl/test-reservation-exhausted-pool/04-delete.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: NamespaceReservation
+  name: test-exhaust-res-2
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: NamespaceReservation
+  name: test-exhaust-res-1
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: NamespacePool
+  name: test-exhausted-pool

--- a/tests/kuttl/test-reservation-lifecycle/00-assert.yaml
+++ b/tests/kuttl/test-reservation-lifecycle/00-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: test-res-lifecycle
+status:
+  ready: 1

--- a/tests/kuttl/test-reservation-lifecycle/00-install.yaml
+++ b/tests/kuttl/test-reservation-lifecycle/00-install.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ephemeral-base
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespacePool
+metadata:
+  name: test-res-lifecycle
+spec:
+  size: 1
+  sizeLimit: 1
+  local: true
+  limitrange:
+    metadata:
+      name: resource-limits
+    spec:
+      limits:
+      - type: Container
+        default:
+          cpu: 200m
+          memory: 512Mi
+        defaultRequest:
+          cpu: 100m
+          memory: 384Mi
+  resourcequotas:
+    items:
+    - metadata:
+        name: compute-resources
+      spec:
+        hard:
+          pods: "10"

--- a/tests/kuttl/test-reservation-lifecycle/01-assert.yaml
+++ b/tests/kuttl/test-reservation-lifecycle/01-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: test-res-lifecycle
+status:
+  state: active

--- a/tests/kuttl/test-reservation-lifecycle/01-install.yaml
+++ b/tests/kuttl/test-reservation-lifecycle/01-install.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: test-res-lifecycle
+spec:
+  requester: kuttl-test
+  duration: "1h"
+  pool: test-res-lifecycle

--- a/tests/kuttl/test-reservation-lifecycle/02-check-namespace.sh
+++ b/tests/kuttl/test-reservation-lifecycle/02-check-namespace.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+RESERVATION_NAME="test-res-lifecycle"
+POOL_NAME="test-res-lifecycle"
+
+NS=$(kubectl get namespacereservation "${RESERVATION_NAME}" -o jsonpath='{.status.namespace}')
+
+if [ -z "${NS}" ]; then
+  echo "ERROR: Reservation ${RESERVATION_NAME} has no namespace assigned"
+  exit 1
+fi
+
+echo "Reservation assigned namespace: ${NS}"
+
+# Save namespace name for cleanup verification in step 04
+echo "${NS}" > /tmp/test-res-lifecycle-ns
+
+# Verify reserved annotation
+RESERVED=$(kubectl get namespace "${NS}" -o jsonpath='{.metadata.annotations.reserved}')
+if [ "${RESERVED}" != "true" ]; then
+  echo "ERROR: Namespace ${NS} is not marked as reserved (reserved=${RESERVED})"
+  exit 1
+fi
+echo "PASS: Namespace ${NS} is marked as reserved"
+
+# Verify pool label
+POOL_LABEL=$(kubectl get namespace "${NS}" -o jsonpath='{.metadata.labels.pool}')
+if [ "${POOL_LABEL}" != "${POOL_NAME}" ]; then
+  echo "ERROR: Namespace pool label is '${POOL_LABEL}', expected '${POOL_NAME}'"
+  exit 1
+fi
+echo "PASS: Namespace ${NS} has correct pool label"
+
+# Verify owner reference points to NamespaceReservation (not NamespacePool)
+OWNER_KIND=$(kubectl get namespace "${NS}" -o jsonpath='{.metadata.ownerReferences[0].kind}')
+if [ "${OWNER_KIND}" != "NamespaceReservation" ]; then
+  echo "ERROR: Namespace owner is '${OWNER_KIND}', expected 'NamespaceReservation'"
+  exit 1
+fi
+echo "PASS: Namespace ${NS} is owned by NamespaceReservation"
+
+# Verify pool status shows reserved: 1, ready: 0
+POOL_READY=$(kubectl get namespacepool "${POOL_NAME}" -o jsonpath='{.status.ready}')
+POOL_RESERVED=$(kubectl get namespacepool "${POOL_NAME}" -o jsonpath='{.status.reserved}')
+if [ "${POOL_READY}" != "0" ]; then
+  echo "ERROR: Pool ready count is ${POOL_READY}, expected 0"
+  exit 1
+fi
+if [ "${POOL_RESERVED}" != "1" ]; then
+  echo "ERROR: Pool reserved count is ${POOL_RESERVED}, expected 1"
+  exit 1
+fi
+echo "PASS: Pool status shows ready=0, reserved=1"
+
+echo "SUCCESS: All namespace checks passed"

--- a/tests/kuttl/test-reservation-lifecycle/02-check-namespace.yaml
+++ b/tests/kuttl/test-reservation-lifecycle/02-check-namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: bash 02-check-namespace.sh

--- a/tests/kuttl/test-reservation-lifecycle/03-delete.yaml
+++ b/tests/kuttl/test-reservation-lifecycle/03-delete.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: NamespaceReservation
+  name: test-res-lifecycle

--- a/tests/kuttl/test-reservation-lifecycle/04-check-cleanup.sh
+++ b/tests/kuttl/test-reservation-lifecycle/04-check-cleanup.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+RESERVATION_NAME="test-res-lifecycle"
+
+# Read namespace name saved by step 02
+NS_FILE="/tmp/test-res-lifecycle-ns"
+if [ ! -f "${NS_FILE}" ]; then
+  echo "ERROR: Namespace name file not found at ${NS_FILE}"
+  exit 1
+fi
+NS=$(cat "${NS_FILE}")
+rm -f "${NS_FILE}"
+
+echo "Waiting for namespace ${NS} to be deleted after reservation cleanup..."
+
+# Wait up to 120 seconds for namespace to be deleted
+for i in $(seq 1 24); do
+  if ! kubectl get namespace "${NS}" > /dev/null 2>&1; then
+    echo "PASS: Namespace ${NS} has been deleted"
+    break
+  fi
+
+  STATUS=$(kubectl get namespace "${NS}" -o jsonpath='{.status.phase}' 2>/dev/null || echo "gone")
+  echo "  Attempt ${i}/24: Namespace ${NS} still exists (phase: ${STATUS})"
+  sleep 5
+done
+
+# Final check
+if kubectl get namespace "${NS}" > /dev/null 2>&1; then
+  STATUS=$(kubectl get namespace "${NS}" -o jsonpath='{.status.phase}' 2>/dev/null || echo "unknown")
+  echo "ERROR: Namespace ${NS} still exists after 120s (phase: ${STATUS})"
+  exit 1
+fi
+
+# Verify reservation is also gone
+if kubectl get namespacereservation "${RESERVATION_NAME}" > /dev/null 2>&1; then
+  echo "ERROR: Reservation ${RESERVATION_NAME} still exists"
+  exit 1
+fi
+
+echo "PASS: Reservation and namespace have been cleaned up"

--- a/tests/kuttl/test-reservation-lifecycle/04-check-cleanup.yaml
+++ b/tests/kuttl/test-reservation-lifecycle/04-check-cleanup.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: bash 04-check-cleanup.sh

--- a/tests/kuttl/test-reservation-lifecycle/05-delete.yaml
+++ b/tests/kuttl/test-reservation-lifecycle/05-delete.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: NamespacePool
+  name: test-res-lifecycle

--- a/tests/kuttl/test-reservation-nonexistent-pool/00-assert.yaml
+++ b/tests/kuttl/test-reservation-nonexistent-pool/00-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: test-res-no-pool
+status:
+  state: waiting

--- a/tests/kuttl/test-reservation-nonexistent-pool/00-install.yaml
+++ b/tests/kuttl/test-reservation-nonexistent-pool/00-install.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ephemeral-base
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: NamespaceReservation
+metadata:
+  name: test-res-no-pool
+spec:
+  requester: kuttl-test
+  duration: "1h"
+  pool: this-pool-does-not-exist

--- a/tests/kuttl/test-reservation-nonexistent-pool/01-check-no-namespace.sh
+++ b/tests/kuttl/test-reservation-nonexistent-pool/01-check-no-namespace.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+RESERVATION_NAME="test-res-no-pool"
+
+# Verify reservation has no namespace assigned
+NS=$(kubectl get namespacereservation "${RESERVATION_NAME}" -o jsonpath='{.status.namespace}')
+
+if [ -n "${NS}" ]; then
+  echo "ERROR: Reservation should not have a namespace assigned, but got: ${NS}"
+  exit 1
+fi
+echo "PASS: Reservation has no namespace assigned"
+
+# Verify reservation is still in waiting state
+STATE=$(kubectl get namespacereservation "${RESERVATION_NAME}" -o jsonpath='{.status.state}')
+if [ "${STATE}" != "waiting" ]; then
+  echo "ERROR: Reservation state is '${STATE}', expected 'waiting'"
+  exit 1
+fi
+echo "PASS: Reservation is in waiting state"
+
+# Verify the pool field in status shows the requested pool
+POOL=$(kubectl get namespacereservation "${RESERVATION_NAME}" -o jsonpath='{.status.pool}')
+if [ "${POOL}" != "this-pool-does-not-exist" ]; then
+  echo "ERROR: Reservation pool is '${POOL}', expected 'this-pool-does-not-exist'"
+  exit 1
+fi
+echo "PASS: Reservation correctly references non-existent pool"
+
+echo "SUCCESS: Reservation correctly waiting for non-existent pool"

--- a/tests/kuttl/test-reservation-nonexistent-pool/01-check-no-namespace.yaml
+++ b/tests/kuttl/test-reservation-nonexistent-pool/01-check-no-namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: bash 01-check-no-namespace.sh

--- a/tests/kuttl/test-reservation-nonexistent-pool/02-delete.yaml
+++ b/tests/kuttl/test-reservation-nonexistent-pool/02-delete.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: NamespaceReservation
+  name: test-res-no-pool


### PR DESCRIPTION
We already have the pieces in place for AWS Codebuild to run the new github action + e2e tests. This included adding secrets to this repo for AWS Codebuild. I added some new kuttl tests that cover:
   - Pool creation and namespace provisioning (with and without ClowdEnvironment)
   - Reservation lifecycle (create, assign, expire, cleanup)
   - Secret copying from source namespaces
   - SizeLimit constraints
   - Error state handling

JIRA: https://redhat.atlassian.net/browse/ENGPROD-9832