### PR TITLE
feat(metrics): add CAPI cleanup duration observability metric

### DIFF
--- a/controllers/cloud.redhat.com/metrics.go
+++ b/controllers/cloud.redhat.com/metrics.go
@@ -75,6 +75,14 @@ var (
 		},
 		[]string{"version"},
 	)
+
+	capiCleanupDurationMetrics = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "capi_cleanup_duration_seconds",
+			Help: "Time elapsed since namespace entered CAPI cleanup state (deletion timestamp to now)",
+		},
+		[]string{"namespace", "reservation"},
+	)
 )
 
 func init() {
@@ -87,5 +95,6 @@ func init() {
 		activeReservationTotalMetrics,
 		resQuantityByUserMetrics,
 		enoVersion,
+		capiCleanupDurationMetrics,
 	)
 }

--- a/controllers/cloud.redhat.com/namespacereservation_controller.go
+++ b/controllers/cloud.redhat.com/namespacereservation_controller.go
@@ -290,6 +290,15 @@ func (r *NamespaceReservationReconciler) handleCAPICleanup(ctx context.Context, 
 		}
 	}
 
+	// Update CAPI cleanup duration metric
+	if res.DeletionTimestamp != nil {
+		elapsedSeconds := time.Since(res.DeletionTimestamp.Time).Seconds()
+		capiCleanupDurationMetrics.With(prometheus.Labels{
+			"namespace":   namespace,
+			"reservation": res.Name,
+		}).Set(elapsedSeconds)
+	}
+
 	log.Info("Deleting CAPI resources before releasing namespace", "namespace", namespace)
 
 	remaining, err := helpers.DeleteCAPIResources(ctx, r.client, namespace)
@@ -313,6 +322,10 @@ func (r *NamespaceReservationReconciler) handleCAPICleanup(ctx context.Context, 
 	}
 
 	log.Info("All CAPI resources removed, releasing finalizer", "namespace", namespace)
+
+	// Delete CAPI cleanup duration metric before removing finalizer
+	capiCleanupDurationMetrics.DeleteLabelValues(namespace, res.Name)
+
 	controllerutil.RemoveFinalizer(res, capiCleanupFinalizer)
 	if err := r.client.Update(ctx, res); err != nil {
 		log.Error(err, "could not remove CAPI cleanup finalizer", "res-name", res.Name)

--- a/controllers/cloud.redhat.com/suite_test.go
+++ b/controllers/cloud.redhat.com/suite_test.go
@@ -536,6 +536,10 @@ var _ = Describe("Metrics", func() {
 		It("should have enoVersion defined", func() {
 			Expect(enoVersion).ToNot(BeNil())
 		})
+
+		It("should have capiCleanupDurationMetrics defined", func() {
+			Expect(capiCleanupDurationMetrics).ToNot(BeNil())
+		})
 	})
 
 	Describe("userNamespaceReservationCount map", func() {


### PR DESCRIPTION
ENO now waits indefinitely for CAPI resources to drain (no timeout). We have zero observability into stuck cleanups caused by credential issues, CAPI controller problems, or OCM API failures.

Adds Prometheus metric to track how long namespaces spend in CAPI cleanup phase.

Closes [ENGPROD-9908](https://redhat.atlassian.net/browse/ENGPROD-9908)

[ENGPROD-9908]: https://redhat.atlassian.net/browse/ENGPROD-9908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ