### PR TITLE
Fix task-deprecated-image-check reference for rh-eno-ci

### DIFF
--- a/.tekton/rh-eno-ci-pull-request.yaml
+++ b/.tekton/rh-eno-ci-pull-request.yaml
@@ -286,7 +286,7 @@ spec:
         - name: name
           value: deprecated-image-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3457a4ca93f8d55f14ebd407532b1223c689eacc34f0abb3003db4111667bdae
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:e78d0d3baf3c8cfc1a5ad278196b74032d9568b143a87c7a79ab780fedfb296e
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rh-eno-ci-push.yaml
+++ b/.tekton/rh-eno-ci-push.yaml
@@ -283,7 +283,7 @@ spec:
         - name: name
           value: deprecated-image-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3457a4ca93f8d55f14ebd407532b1223c689eacc34f0abb3003db4111667bdae
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:e78d0d3baf3c8cfc1a5ad278196b74032d9568b143a87c7a79ab780fedfb296e
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
This PR is updating the deprecated-image-check task for rh-eno-ci to a supported ref. This will allow Conforma to end in green hopefully, as the pr-group and rh-eno-ci pipeline show.
the ephemeral-namespace-operator check is failing because is using the rh-eno-ci snapshot from main that is fixed in this PR.