### PR TITLE
fix: unblock namespace deletion when last ROSA node pool cannot be deleted

### DIFF
--- a/controllers/cloud.redhat.com/helpers/capi.go
+++ b/controllers/cloud.redhat.com/helpers/capi.go
@@ -41,9 +41,13 @@ func DeleteCAPIResources(ctx context.Context, cl client.Client, namespace string
 }
 
 // RemoveStuckROSAMachinePoolFinalizers removes the controller finalizer from ROSAMachinePool
-// resources that are stuck in deletion due to the OCM API rejecting an update with HTTP 400 for
-// an immutable field (e.g. 'aws_node_pool.root_volume.size' is not allowed), AND whose owning
+// resources that are stuck in deletion due to a known unrecoverable OCM error, AND whose owning
 // Cluster confirms it is blocked waiting on that MachinePool deletion. Both conditions must hold.
+// Known stuck states:
+//   - OCM rejects with HTTP 400 for an immutable field (e.g. 'aws_node_pool.root_volume.size')
+//   - OCM rejects with HTTP 400 "The last node pool can not be deleted from a cluster" — in this
+//     case the condition stays at WaitingForRosaControlPlane rather than ReconciliationFailed.
+//
 // Returns (false, nil) when the ROSAMachinePool CRD is not installed on the cluster.
 func RemoveStuckROSAMachinePoolFinalizers(ctx context.Context, cl client.Client, namespace string) (bool, error) {
 	const (
@@ -73,8 +77,8 @@ func RemoveStuckROSAMachinePoolFinalizers(ctx context.Context, cl client.Client,
 			continue
 		}
 
-		// Only act when the pool is stuck due to an OCM 400 error on an immutable field.
-		if !rosaPoolHasImmutableFieldError(pool) {
+		// Only act when the pool is in a known stuck deletion state.
+		if !rosaPoolHasImmutableFieldError(pool) && !rosaPoolStuckWaitingForControlPlane(pool) {
 			continue
 		}
 
@@ -119,6 +123,28 @@ func rosaPoolHasImmutableFieldError(pool *unstructured.Unstructured) bool {
 		}
 		msg, _ := cond["message"].(string)
 		return strings.Contains(msg, "Attribute 'aws_node_pool.root_volume.size' is not allowed")
+	}
+	return false
+}
+
+// rosaPoolStuckWaitingForControlPlane returns true when a ROSAMachinePool being deleted has its
+// RosaMachinePoolReady condition stuck at WaitingForRosaControlPlane. This happens when OCM
+// rejects the individual node-pool delete with "The last node pool can not be deleted from a
+// cluster" — the controller returns the error without transitioning the condition to
+// ReconciliationFailed, so the error is only visible in controller logs.
+func rosaPoolStuckWaitingForControlPlane(pool *unstructured.Unstructured) bool {
+	if pool.GetDeletionTimestamp().IsZero() {
+		return false
+	}
+	conditions, _, _ := unstructured.NestedSlice(pool.Object, "status", "conditions")
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if cond["type"] == "RosaMachinePoolReady" && cond["status"] == "False" && cond["reason"] == "WaitingForRosaControlPlane" {
+			return true
+		}
 	}
 	return false
 }

--- a/controllers/cloud.redhat.com/helpers/helpers_test.go
+++ b/controllers/cloud.redhat.com/helpers/helpers_test.go
@@ -967,7 +967,8 @@ var _ = Describe("Helper Functions", func() {
 		// makePool builds an unstructured ROSAMachinePool with a deletionTimestamp, the CAPA
 		// finalizer, and a dummy extra finalizer (so the object is not GC'd when we remove the
 		// real one, allowing us to assert on the resulting finalizer list).
-		makePool := func(withImmutableError bool) *unstructured.Unstructured {
+		// errorType controls which stuck condition is set: "immutable", "lastNodePool", or "" for none.
+		makePool := func(errorType string) *unstructured.Unstructured {
 			now := metav1.Now()
 			pool := &unstructured.Unstructured{}
 			pool.SetGroupVersionKind(schema.GroupVersionKind{
@@ -981,13 +982,22 @@ var _ = Describe("Helper Functions", func() {
 			pool.SetDeletionTimestamp(&now)
 			pool.SetFinalizers([]string{poolFinalizer, "dummy-finalizer"})
 
-			if withImmutableError {
+			switch errorType {
+			case "immutable":
 				Expect(unstructured.SetNestedSlice(pool.Object, []interface{}{
 					map[string]interface{}{
 						"type":    "RosaMachinePoolReady",
 						"status":  "False",
 						"reason":  "ReconciliationFailed",
 						"message": "Attribute 'aws_node_pool.root_volume.size' is not allowed",
+					},
+				}, "status", "conditions")).To(Succeed())
+			case "lastNodePool":
+				Expect(unstructured.SetNestedSlice(pool.Object, []interface{}{
+					map[string]interface{}{
+						"type":   "RosaMachinePoolReady",
+						"status": "False",
+						"reason": "WaitingForRosaControlPlane",
 					},
 				}, "status", "conditions")).To(Succeed())
 			}
@@ -1016,7 +1026,7 @@ var _ = Describe("Helper Functions", func() {
 		}
 
 		It("should remove finalizer when cluster is gone and pool has immutable field error", func() {
-			pool := makePool(true)
+			pool := makePool("immutable")
 			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool).Build()
 
 			patched, err := RemoveStuckROSAMachinePoolFinalizers(ctx, c, testNamespace)
@@ -1029,8 +1039,8 @@ var _ = Describe("Helper Functions", func() {
 			Expect(fetched.GetFinalizers()).To(ConsistOf("dummy-finalizer"))
 		})
 
-		It("should remove finalizer when cluster is WaitingForWorkersDeletion", func() {
-			pool := makePool(true)
+		It("should remove finalizer when cluster is WaitingForWorkersDeletion and pool has immutable field error", func() {
+			pool := makePool("immutable")
 			cluster := makeCluster("WaitingForWorkersDeletion")
 			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool, cluster).Build()
 
@@ -1044,8 +1054,37 @@ var _ = Describe("Helper Functions", func() {
 			Expect(fetched.GetFinalizers()).To(ConsistOf("dummy-finalizer"))
 		})
 
+		It("should remove finalizer when cluster is WaitingForWorkersDeletion and pool has last-node-pool error", func() {
+			pool := makePool("lastNodePool")
+			cluster := makeCluster("WaitingForWorkersDeletion")
+			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool, cluster).Build()
+
+			patched, err := RemoveStuckROSAMachinePoolFinalizers(ctx, c, testNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(patched).To(BeTrue())
+
+			fetched := &unstructured.Unstructured{}
+			fetched.SetGroupVersionKind(pool.GroupVersionKind())
+			Expect(c.Get(ctx, types.NamespacedName{Name: "workers", Namespace: testNamespace}, fetched)).To(Succeed())
+			Expect(fetched.GetFinalizers()).To(ConsistOf("dummy-finalizer"))
+		})
+
+		It("should remove finalizer when cluster is gone and pool has last-node-pool error", func() {
+			pool := makePool("lastNodePool")
+			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool).Build()
+
+			patched, err := RemoveStuckROSAMachinePoolFinalizers(ctx, c, testNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(patched).To(BeTrue())
+
+			fetched := &unstructured.Unstructured{}
+			fetched.SetGroupVersionKind(pool.GroupVersionKind())
+			Expect(c.Get(ctx, types.NamespacedName{Name: "workers", Namespace: testNamespace}, fetched)).To(Succeed())
+			Expect(fetched.GetFinalizers()).To(ConsistOf("dummy-finalizer"))
+		})
+
 		It("should not remove finalizer when cluster exists but is not WaitingForWorkersDeletion", func() {
-			pool := makePool(true)
+			pool := makePool("immutable")
 			cluster := makeCluster("WaitingForControlPlaneDeletion")
 			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool, cluster).Build()
 
@@ -1059,9 +1098,19 @@ var _ = Describe("Helper Functions", func() {
 			Expect(fetched.GetFinalizers()).To(ConsistOf(poolFinalizer, "dummy-finalizer"))
 		})
 
-		It("should not remove finalizer when pool lacks the immutable field error", func() {
-			pool := makePool(false)
+		It("should not remove finalizer when pool has no known stuck condition", func() {
+			pool := makePool("")
 			cluster := makeCluster("WaitingForWorkersDeletion")
+			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool, cluster).Build()
+
+			patched, err := RemoveStuckROSAMachinePoolFinalizers(ctx, c, testNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(patched).To(BeFalse())
+		})
+
+		It("should not remove finalizer when pool with last-node-pool error has no matching cluster condition", func() {
+			pool := makePool("lastNodePool")
+			cluster := makeCluster("WaitingForControlPlaneDeletion")
 			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool, cluster).Build()
 
 			patched, err := RemoveStuckROSAMachinePoolFinalizers(ctx, c, testNamespace)


### PR DESCRIPTION
## Summary

- Adds a second detection path in `RemoveStuckROSAMachinePoolFinalizers` for the OCM \"last node pool\" error
- OCM rejects node-pool deletion with HTTP 400 when the pool is the only one on a cluster; unlike the existing immutable-field case, the CAPA controller never updates the `RosaMachinePoolReady` condition to `ReconciliationFailed` — it stays stuck at `WaitingForRosaControlPlane` and only appears in controller logs
- The new `rosaPoolStuckWaitingForControlPlane` helper detects this state; the existing `clusterWaitingForWorkersDeletion` guard still applies, requiring the owning Cluster to have a `Deleting: WaitingForWorkersDeletion` condition before any finalizer is removed

## Root cause

When a ROSA HCP cluster with a single node pool is deleted, the CAPI Cluster controller marks the `MachinePool` for deletion first. The `ROSAMachinePool` controller then calls OCM to delete the node pool, but OCM refuses with:

```
CLUSTERS-MGMT-400: The last node pool can not be deleted from a cluster.
```

The controller returns this error without updating the status condition, leaving `RosaMachinePoolReady: WaitingForRosaControlPlane` indefinitely. The `ROSAMachinePool` finalizer never clears, so the `Cluster` finalizer never clears, and the namespace stays stuck in `Deleting` forever.

## Test plan

- [ ] Existing 61 helper specs still pass
- [ ] 4 new specs added for `lastNodePool` error type (cluster gone, cluster waiting, cluster not-waiting, no stuck condition)
- [ ] `make pre-push` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)