### PR TITLE
fix: use time-based threshold to unblock stuck ROSAMachinePool finalizers

### DIFF
--- a/controllers/cloud.redhat.com/helpers/capi.go
+++ b/controllers/cloud.redhat.com/helpers/capi.go
@@ -3,7 +3,7 @@ package helpers
 import (
 	"context"
 	"fmt"
-	"strings"
+	"time"
 
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -40,13 +40,15 @@ func DeleteCAPIResources(ctx context.Context, cl client.Client, namespace string
 	return len(clusterList.Items) > 0, nil
 }
 
+// stuckDeletionThreshold is how long a ROSAMachinePool must have been in deletion before its
+// finalizer is force-removed. This covers transient OCM errors (e.g. 429 rate-limiting) that
+// the controller cannot recover from on its own within a reasonable window.
+const stuckDeletionThreshold = time.Hour
+
 // RemoveStuckROSAMachinePoolFinalizers removes the controller finalizer from ROSAMachinePool
-// resources that are stuck in deletion due to a known unrecoverable OCM error, AND whose owning
-// Cluster confirms it is blocked waiting on that MachinePool deletion. Both conditions must hold.
-// Known stuck states:
-//   - OCM rejects with HTTP 400 for an immutable field (e.g. 'aws_node_pool.root_volume.size')
-//   - OCM rejects with HTTP 400 "The last node pool can not be deleted from a cluster" — in this
-//     case the condition stays at WaitingForRosaControlPlane rather than ReconciliationFailed.
+// resources that have been stuck in deletion for longer than stuckDeletionThreshold, and whose
+// owning Cluster confirms it is blocked waiting on that MachinePool deletion. Both conditions
+// must hold.
 //
 // Returns (false, nil) when the ROSAMachinePool CRD is not installed on the cluster.
 func RemoveStuckROSAMachinePoolFinalizers(ctx context.Context, cl client.Client, namespace string) (bool, error) {
@@ -77,8 +79,8 @@ func RemoveStuckROSAMachinePoolFinalizers(ctx context.Context, cl client.Client,
 			continue
 		}
 
-		// Only act when the pool is in a known stuck deletion state.
-		if !rosaPoolHasImmutableFieldError(pool) && !rosaPoolStuckWaitingForControlPlane(pool) {
+		// Only act when deletion has been stuck long enough to rule out transient errors.
+		if time.Since(pool.GetDeletionTimestamp().Time) < stuckDeletionThreshold {
 			continue
 		}
 
@@ -103,50 +105,6 @@ func RemoveStuckROSAMachinePoolFinalizers(ctx context.Context, cl client.Client,
 	}
 
 	return patched, nil
-}
-
-// rosaPoolHasImmutableFieldError returns true when the ROSAMachinePool's RosaMachinePoolReady
-// condition shows a ReconciliationFailed caused by the OCM API rejecting the immutable field
-// 'aws_node_pool.root_volume.size' with HTTP 400.
-func rosaPoolHasImmutableFieldError(pool *unstructured.Unstructured) bool {
-	conditions, _, _ := unstructured.NestedSlice(pool.Object, "status", "conditions")
-	for _, c := range conditions {
-		cond, ok := c.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		condType, _ := cond["type"].(string)
-		condStatus, _ := cond["status"].(string)
-		condReason, _ := cond["reason"].(string)
-		if condType != "RosaMachinePoolReady" || condStatus != "False" || condReason != "ReconciliationFailed" {
-			continue
-		}
-		msg, _ := cond["message"].(string)
-		return strings.Contains(msg, "Attribute 'aws_node_pool.root_volume.size' is not allowed")
-	}
-	return false
-}
-
-// rosaPoolStuckWaitingForControlPlane returns true when a ROSAMachinePool being deleted has its
-// RosaMachinePoolReady condition stuck at WaitingForRosaControlPlane. This happens when OCM
-// rejects the individual node-pool delete with "The last node pool can not be deleted from a
-// cluster" — the controller returns the error without transitioning the condition to
-// ReconciliationFailed, so the error is only visible in controller logs.
-func rosaPoolStuckWaitingForControlPlane(pool *unstructured.Unstructured) bool {
-	if pool.GetDeletionTimestamp().IsZero() {
-		return false
-	}
-	conditions, _, _ := unstructured.NestedSlice(pool.Object, "status", "conditions")
-	for _, c := range conditions {
-		cond, ok := c.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if cond["type"] == "RosaMachinePoolReady" && cond["status"] == "False" && cond["reason"] == "WaitingForRosaControlPlane" {
-			return true
-		}
-	}
-	return false
 }
 
 // clusterWaitingForWorkersDeletion returns true when the named Cluster's Deleting condition

--- a/controllers/cloud.redhat.com/helpers/helpers_test.go
+++ b/controllers/cloud.redhat.com/helpers/helpers_test.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"context"
 	"testing"
+	"time"
 
 	clowder "github.com/RedHatInsights/clowder/apis/cloud.redhat.com/v1alpha1"
 	crd "github.com/RedHatInsights/ephemeral-namespace-operator/apis/cloud.redhat.com/v1alpha1"
@@ -964,12 +965,11 @@ var _ = Describe("Helper Functions", func() {
 			)
 		})
 
-		// makePool builds an unstructured ROSAMachinePool with a deletionTimestamp, the CAPA
-		// finalizer, and a dummy extra finalizer (so the object is not GC'd when we remove the
-		// real one, allowing us to assert on the resulting finalizer list).
-		// errorType controls which stuck condition is set: "immutable", "lastNodePool", or "" for none.
-		makePool := func(errorType string) *unstructured.Unstructured {
-			now := metav1.Now()
+		// makePool builds an unstructured ROSAMachinePool with a deletionTimestamp set
+		// deletionAge ago, the CAPA finalizer, and a dummy extra finalizer (so the object is
+		// not GC'd when we remove the real one, allowing us to assert on the resulting finalizer list).
+		makePool := func(deletionAge time.Duration) *unstructured.Unstructured {
+			deletionTime := metav1.NewTime(time.Now().Add(-deletionAge))
 			pool := &unstructured.Unstructured{}
 			pool.SetGroupVersionKind(schema.GroupVersionKind{
 				Group:   "infrastructure.cluster.x-k8s.io",
@@ -979,28 +979,8 @@ var _ = Describe("Helper Functions", func() {
 			pool.SetName("workers")
 			pool.SetNamespace(testNamespace)
 			pool.SetLabels(map[string]string{"cluster.x-k8s.io/cluster-name": clusterName})
-			pool.SetDeletionTimestamp(&now)
+			pool.SetDeletionTimestamp(&deletionTime)
 			pool.SetFinalizers([]string{poolFinalizer, "dummy-finalizer"})
-
-			switch errorType {
-			case "immutable":
-				Expect(unstructured.SetNestedSlice(pool.Object, []interface{}{
-					map[string]interface{}{
-						"type":    "RosaMachinePoolReady",
-						"status":  "False",
-						"reason":  "ReconciliationFailed",
-						"message": "Attribute 'aws_node_pool.root_volume.size' is not allowed",
-					},
-				}, "status", "conditions")).To(Succeed())
-			case "lastNodePool":
-				Expect(unstructured.SetNestedSlice(pool.Object, []interface{}{
-					map[string]interface{}{
-						"type":   "RosaMachinePoolReady",
-						"status": "False",
-						"reason": "WaitingForRosaControlPlane",
-					},
-				}, "status", "conditions")).To(Succeed())
-			}
 			return pool
 		}
 
@@ -1025,8 +1005,8 @@ var _ = Describe("Helper Functions", func() {
 			return cluster
 		}
 
-		It("should remove finalizer when cluster is gone and pool has immutable field error", func() {
-			pool := makePool("immutable")
+		It("should remove finalizer when cluster is gone and pool has been deleting for >1h", func() {
+			pool := makePool(2 * time.Hour)
 			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool).Build()
 
 			patched, err := RemoveStuckROSAMachinePoolFinalizers(ctx, c, testNamespace)
@@ -1039,8 +1019,8 @@ var _ = Describe("Helper Functions", func() {
 			Expect(fetched.GetFinalizers()).To(ConsistOf("dummy-finalizer"))
 		})
 
-		It("should remove finalizer when cluster is WaitingForWorkersDeletion and pool has immutable field error", func() {
-			pool := makePool("immutable")
+		It("should remove finalizer when cluster is WaitingForWorkersDeletion and pool has been deleting for >1h", func() {
+			pool := makePool(2 * time.Hour)
 			cluster := makeCluster("WaitingForWorkersDeletion")
 			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool, cluster).Build()
 
@@ -1054,38 +1034,9 @@ var _ = Describe("Helper Functions", func() {
 			Expect(fetched.GetFinalizers()).To(ConsistOf("dummy-finalizer"))
 		})
 
-		It("should remove finalizer when cluster is WaitingForWorkersDeletion and pool has last-node-pool error", func() {
-			pool := makePool("lastNodePool")
+		It("should not remove finalizer when pool has been deleting for less than 1h", func() {
+			pool := makePool(30 * time.Minute)
 			cluster := makeCluster("WaitingForWorkersDeletion")
-			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool, cluster).Build()
-
-			patched, err := RemoveStuckROSAMachinePoolFinalizers(ctx, c, testNamespace)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(patched).To(BeTrue())
-
-			fetched := &unstructured.Unstructured{}
-			fetched.SetGroupVersionKind(pool.GroupVersionKind())
-			Expect(c.Get(ctx, types.NamespacedName{Name: "workers", Namespace: testNamespace}, fetched)).To(Succeed())
-			Expect(fetched.GetFinalizers()).To(ConsistOf("dummy-finalizer"))
-		})
-
-		It("should remove finalizer when cluster is gone and pool has last-node-pool error", func() {
-			pool := makePool("lastNodePool")
-			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool).Build()
-
-			patched, err := RemoveStuckROSAMachinePoolFinalizers(ctx, c, testNamespace)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(patched).To(BeTrue())
-
-			fetched := &unstructured.Unstructured{}
-			fetched.SetGroupVersionKind(pool.GroupVersionKind())
-			Expect(c.Get(ctx, types.NamespacedName{Name: "workers", Namespace: testNamespace}, fetched)).To(Succeed())
-			Expect(fetched.GetFinalizers()).To(ConsistOf("dummy-finalizer"))
-		})
-
-		It("should not remove finalizer when cluster exists but is not WaitingForWorkersDeletion", func() {
-			pool := makePool("immutable")
-			cluster := makeCluster("WaitingForControlPlaneDeletion")
 			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool, cluster).Build()
 
 			patched, err := RemoveStuckROSAMachinePoolFinalizers(ctx, c, testNamespace)
@@ -1098,24 +1049,19 @@ var _ = Describe("Helper Functions", func() {
 			Expect(fetched.GetFinalizers()).To(ConsistOf(poolFinalizer, "dummy-finalizer"))
 		})
 
-		It("should not remove finalizer when pool has no known stuck condition", func() {
-			pool := makePool("")
-			cluster := makeCluster("WaitingForWorkersDeletion")
-			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool, cluster).Build()
-
-			patched, err := RemoveStuckROSAMachinePoolFinalizers(ctx, c, testNamespace)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(patched).To(BeFalse())
-		})
-
-		It("should not remove finalizer when pool with last-node-pool error has no matching cluster condition", func() {
-			pool := makePool("lastNodePool")
+		It("should not remove finalizer when cluster exists but is not WaitingForWorkersDeletion", func() {
+			pool := makePool(2 * time.Hour)
 			cluster := makeCluster("WaitingForControlPlaneDeletion")
 			c := fake.NewClientBuilder().WithScheme(rosaScheme).WithObjects(pool, cluster).Build()
 
 			patched, err := RemoveStuckROSAMachinePoolFinalizers(ctx, c, testNamespace)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(patched).To(BeFalse())
+
+			fetched := &unstructured.Unstructured{}
+			fetched.SetGroupVersionKind(pool.GroupVersionKind())
+			Expect(c.Get(ctx, types.NamespacedName{Name: "workers", Namespace: testNamespace}, fetched)).To(Succeed())
+			Expect(fetched.GetFinalizers()).To(ConsistOf(poolFinalizer, "dummy-finalizer"))
 		})
 
 		It("should return false when no ROSAMachinePool resources exist", func() {


### PR DESCRIPTION
## Summary

- Replaces the error-type allowlist (`rosaPoolHasImmutableFieldError` / `rosaPoolStuckWaitingForControlPlane`) with a single time-based guard: if a `ROSAMachinePool` has been in deleting state for longer than **1 hour**, force-remove its controller finalizer
- Fixes a gap where OCM 429 (rate-limiting) errors left the pool permanently stuck — the old code only handled HTTP 400 immutable-field and last-node-pool errors
- The owning `Cluster` must still be in `WaitingForWorkersDeletion` (or be gone entirely) before the finalizer is removed

## Root cause

`ephemeral-vlduhl-cluster` was stuck in `Deleting` for ~19 hours. Investigation via `oc get rosamachinepool workers -n ephemeral-vlduhl -o yaml` showed:
```
type: RosaMachinePoolReady
reason: ReconciliationFailed
message: 'failed to update ROSAMachinePool: status is 429 ... CLUSTERS-MGMT-429: Too Many Requests'
```
The previous allowlist did not match this condition, so `RemoveStuckROSAMachinePoolFinalizers` silently skipped the pool.

## Test plan

- [ ] Existing helpers test suite passes (`go test ./controllers/cloud.redhat.com/helpers/...`)
- [ ] New test: pool deleting for `30m` → finalizer NOT removed
- [ ] New test: pool deleting for `2h`, cluster `WaitingForWorkersDeletion` → finalizer removed
- [ ] New test: pool deleting for `2h`, cluster gone → finalizer removed
- [ ] New test: pool deleting for `2h`, cluster NOT `WaitingForWorkersDeletion` → finalizer NOT removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)