### PR TITLE
feat(metrics): add reservations_by_requester_total metric and dashboard panels

### DIFF
--- a/controllers/cloud.redhat.com/metrics.go
+++ b/controllers/cloud.redhat.com/metrics.go
@@ -5,17 +5,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-var userNamespaceReservationCount = map[string]int{}
-
 var (
-	totalSuccessfulPoolReservationsCountMetrics = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "successful_pool_reservations_total",
-			Help: "Total successful reservations from each pool",
-		},
-		[]string{"pool"},
-	)
-
 	totalFailedPoolReservationsCountMetrics = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "failed_pool_reservations_total",
@@ -60,14 +50,6 @@ var (
 		[]string{"controller"},
 	)
 
-	resQuantityByUserMetrics = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "res_quantity_by_user_count",
-			Help: "Quantity of reservations by user",
-		},
-		[]string{"user"},
-	)
-
 	enoVersion = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "eno_version",
@@ -95,13 +77,11 @@ var (
 
 func init() {
 	metrics.Registry.MustRegister(
-		totalSuccessfulPoolReservationsCountMetrics,
 		totalFailedPoolReservationsCountMetrics,
 		averageRequestedDurationMetrics,
 		averageNamespaceCreationMetrics,
 		averageReservationToDeploymentMetrics,
 		activeReservationTotalMetrics,
-		resQuantityByUserMetrics,
 		enoVersion,
 		capiCleanupDurationMetrics,
 		reservationsByRequesterTotalMetrics,

--- a/controllers/cloud.redhat.com/metrics.go
+++ b/controllers/cloud.redhat.com/metrics.go
@@ -83,6 +83,14 @@ var (
 		},
 		[]string{"namespace", "reservation"},
 	)
+
+	reservationsByRequesterTotalMetrics = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "reservations_by_requester_total",
+			Help: "Total number of namespace reservations by requester and pool",
+		},
+		[]string{"requester", "pool"},
+	)
 )
 
 func init() {
@@ -96,5 +104,6 @@ func init() {
 		resQuantityByUserMetrics,
 		enoVersion,
 		capiCleanupDurationMetrics,
+		reservationsByRequesterTotalMetrics,
 	)
 }

--- a/controllers/cloud.redhat.com/namespacereservation_controller.go
+++ b/controllers/cloud.redhat.com/namespacereservation_controller.go
@@ -247,6 +247,8 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 
 		resQuantityByUserMetrics.With(prometheus.Labels{"user": res.Spec.Requester}).Set(float64(userNamespaceReservationCount[res.Spec.Requester]))
 
+		reservationsByRequesterTotalMetrics.With(prometheus.Labels{"requester": res.Spec.Requester, "pool": res.Status.Pool}).Inc()
+
 		averageRequestedDurationMetrics.With(prometheus.Labels{"controller": "namespacereservation", "pool": res.Spec.Pool}).Observe(float64(duration.Hours()))
 
 		elapsed := time.Since(res.CreationTimestamp.Time)

--- a/controllers/cloud.redhat.com/namespacereservation_controller.go
+++ b/controllers/cloud.redhat.com/namespacereservation_controller.go
@@ -239,14 +239,6 @@ func (r *NamespaceReservationReconciler) Reconcile(ctx context.Context, req ctrl
 			return ctrl.Result{}, err
 		}
 
-		if _, ok := userNamespaceReservationCount[res.Spec.Requester]; !ok {
-			userNamespaceReservationCount[res.Spec.Requester] = 0
-		}
-
-		userNamespaceReservationCount[res.Spec.Requester]++
-
-		resQuantityByUserMetrics.With(prometheus.Labels{"user": res.Spec.Requester}).Set(float64(userNamespaceReservationCount[res.Spec.Requester]))
-
 		reservationsByRequesterTotalMetrics.With(prometheus.Labels{"requester": res.Spec.Requester, "pool": res.Status.Pool}).Inc()
 
 		averageRequestedDurationMetrics.With(prometheus.Labels{"controller": "namespacereservation", "pool": res.Spec.Pool}).Observe(float64(duration.Hours()))
@@ -386,8 +378,6 @@ func (r *NamespaceReservationReconciler) reserveNamespace(ctx context.Context, r
 		r.log.Error(err, "could not apply rolebindings for namespace", "namespace", readyNsName)
 		return err
 	}
-
-	totalSuccessfulPoolReservationsCountMetrics.With(prometheus.Labels{"pool": res.Spec.Pool}).Inc()
 
 	return nil
 }

--- a/controllers/cloud.redhat.com/suite_test.go
+++ b/controllers/cloud.redhat.com/suite_test.go
@@ -509,10 +509,6 @@ var _ = Describe("Poller", func() {
 // Additional tests for Metrics functionality
 var _ = Describe("Metrics", func() {
 	Describe("Prometheus Metrics", func() {
-		It("should have totalSuccessfulPoolReservationsCountMetrics defined", func() {
-			Expect(totalSuccessfulPoolReservationsCountMetrics).ToNot(BeNil())
-		})
-
 		It("should have totalFailedPoolReservationsCountMetrics defined", func() {
 			Expect(totalFailedPoolReservationsCountMetrics).ToNot(BeNil())
 		})
@@ -533,8 +529,8 @@ var _ = Describe("Metrics", func() {
 			Expect(activeReservationTotalMetrics).ToNot(BeNil())
 		})
 
-		It("should have resQuantityByUserMetrics defined", func() {
-			Expect(resQuantityByUserMetrics).ToNot(BeNil())
+		It("should have reservationsByRequesterTotalMetrics defined", func() {
+			Expect(reservationsByRequesterTotalMetrics).ToNot(BeNil())
 		})
 
 		It("should have enoVersion defined", func() {
@@ -546,11 +542,4 @@ var _ = Describe("Metrics", func() {
 		})
 	})
 
-	Describe("userNamespaceReservationCount map", func() {
-		It("should allow adding and retrieving values", func() {
-			// Test the map functionality
-			userNamespaceReservationCount["test-user"] = 5
-			Expect(userNamespaceReservationCount["test-user"]).To(Equal(5))
-		})
-	})
 })

--- a/dashboards/ephemeral-ns-operator-dashboard.yaml
+++ b/dashboards/ephemeral-ns-operator-dashboard.yaml
@@ -1859,6 +1859,359 @@ data:
           "title": "Top Users by Active Reservations",
           "transparent": true,
           "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "center",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": true,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Total Reservations"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 70
+          },
+          "id": 58,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Total Reservations"
+              }
+            ]
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sort_desc(sum by(requester) (reservations_by_requester_total))",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "{{requester}}",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Total Reservations by Requester",
+          "transparent": true,
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 50
+                  },
+                  {
+                    "color": "red",
+                    "value": 100
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 70
+          },
+          "id": 59,
+          "options": {
+            "displayMode": "gradient",
+            "maxVizHeight": 300,
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(10, sum by(requester) (reservations_by_requester_total))",
+              "instant": true,
+              "legendFormat": "{{requester}}",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Top Requesters (All Time)",
+          "transparent": true,
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 80
+          },
+          "id": 60,
+          "options": {
+            "displayLabels": [
+              "name",
+              "percent"
+            ],
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "value",
+                "percent"
+              ]
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum by(pool) (reservations_by_requester_total)",
+              "instant": true,
+              "legendFormat": "{{pool}}",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Reservations by Pool",
+          "transparent": true,
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Reservations",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 30,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 80
+          },
+          "id": 61,
+          "options": {
+            "legend": {
+              "calcs": ["last", "max"],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum by(pool) (increase(reservations_by_requester_total[1h]))",
+              "legendFormat": "{{pool}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Reservations per Hour by Pool",
+          "transparent": true,
+          "type": "timeseries"
         }
       ],
       "preload": false,

--- a/dashboards/ephemeral-ns-operator-dashboard.yaml
+++ b/dashboards/ephemeral-ns-operator-dashboard.yaml
@@ -92,7 +92,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(successful_pool_reservations_total{pool=~\"$pools\"})",
+              "expr": "sum(reservations_by_requester_total{pool=~\"$pools\"})",
               "format": "time_series",
               "legendFormat": "{{pool}}",
               "range": true,
@@ -352,25 +352,12 @@ data:
               "dimensions": {},
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sort_desc(sum by(user) (res_quantity_by_user_count{user!~\".*smoke-test.*|.*pr-check-.*|automation-.*|.*-check-bot|.*ephemeral-base.*|edge-api.*|notifications.*\"}))",
-              "expression": "",
+              "expr": "sort_desc(sum by(requester) (reservations_by_requester_total{requester!~\".*smoke-test.*|.*pr-check-.*|automation-.*|.*-check-bot|.*ephemeral-base.*|edge-api.*|notifications.*\"}))",
               "format": "table",
-              "id": "",
-              "instant": false,
-              "label": "",
-              "legendFormat": "{{user}}",
-              "matchExact": true,
-              "metricEditorMode": 0,
-              "metricName": "",
-              "metricQueryType": 0,
-              "namespace": "",
-              "period": "",
-              "queryMode": "Metrics",
-              "range": true,
-              "refId": "A",
-              "region": "default",
-              "sqlExpression": "",
-              "statistic": "Average"
+              "instant": true,
+              "legendFormat": "{{requester}}",
+              "range": false,
+              "refId": "A"
             }
           ],
           "title": "Reservation Total By User",
@@ -1502,372 +1489,6 @@ data:
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 50,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "normal"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 24,
-            "x": 0,
-            "y": 40
-          },
-          "id": 54,
-          "options": {
-            "legend": {
-              "calcs": ["last", "max"],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true,
-              "sortBy": "Last",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "pluginVersion": "11.6.3",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "sum by(user_group) (label_replace(res_quantity_by_user_count{user!~\"^[a-z]+$\"}, \"user_group\", \"$1\", \"user\", \"^(.+?)(?:-(?:bonfire-tekton|tekton-insights|pr-check|iqe-integration-test|pipelinerun|gh-pr-and-build|PR-\\\\d+|\\\\d{3,}|[a-z0-9]{5,6}))+$\"))",
-              "legendFormat": "{{user_group}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Active Reservations by App (CI/Automation)",
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 5
-                  },
-                  {
-                    "color": "red",
-                    "value": 10
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 0,
-            "y": 50
-          },
-          "id": 55,
-          "options": {
-            "displayMode": "gradient",
-            "maxVizHeight": 300,
-            "minVizHeight": 16,
-            "minVizWidth": 8,
-            "namePlacement": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showUnfilled": true,
-            "sizing": "auto",
-            "valueMode": "color"
-          },
-          "pluginVersion": "11.6.3",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sort_desc(sum by(user_group) (label_replace(res_quantity_by_user_count{user!~\"^[a-z]+$\"}, \"user_group\", \"$1\", \"user\", \"^(.+?)(?:-(?:bonfire-tekton|tekton-insights|pr-check|iqe-integration-test|pipelinerun|gh-pr-and-build|PR-\\\\d+|\\\\d{3,}|[a-z0-9]{5,6}))+$\")))",
-              "instant": true,
-              "legendFormat": "{{user_group}}",
-              "range": false,
-              "refId": "A"
-            }
-          ],
-          "title": "Top Apps by Active Reservations (CI/Automation)",
-          "transparent": true,
-          "type": "bargauge"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 50,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "normal"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 12,
-            "y": 50
-          },
-          "id": 56,
-          "options": {
-            "legend": {
-              "calcs": ["last", "max"],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true,
-              "sortBy": "Last",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "pluginVersion": "11.6.3",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "sum by(user) (res_quantity_by_user_count{user=~\"^[a-z]+$\"})",
-              "legendFormat": "{{user}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Active Reservations by User (Stacked)",
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 3
-                  },
-                  {
-                    "color": "red",
-                    "value": 5
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 0,
-            "y": 60
-          },
-          "id": 57,
-          "options": {
-            "displayMode": "gradient",
-            "maxVizHeight": 300,
-            "minVizHeight": 16,
-            "minVizWidth": 8,
-            "namePlacement": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showUnfilled": true,
-            "sizing": "auto",
-            "valueMode": "color"
-          },
-          "pluginVersion": "11.6.3",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sort_desc(sum by(user) (res_quantity_by_user_count{user=~\"^[a-z]+$\"}))",
-              "instant": true,
-              "legendFormat": "{{user}}",
-              "range": false,
-              "refId": "A"
-            }
-          ],
-          "title": "Top Users by Active Reservations",
-          "transparent": true,
-          "type": "bargauge"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
                 "mode": "thresholds"
               },
               "custom": {
@@ -1907,7 +1528,7 @@ data:
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 70
+            "y": 40
           },
           "id": 58,
           "options": {
@@ -1991,7 +1612,7 @@ data:
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 70
+            "y": 40
           },
           "id": 59,
           "options": {
@@ -2066,7 +1687,7 @@ data:
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 80
+            "y": 50
           },
           "id": 60,
           "options": {
@@ -2177,7 +1798,7 @@ data:
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 80
+            "y": 50
           },
           "id": 61,
           "options": {


### PR DESCRIPTION
## Summary

Adds a new Prometheus Counter metric `reservations_by_requester_total` with labels `requester` and `pool` to track which individual requesters have been reserving namespaces and from which pools over time.

Also removes two redundant metrics that are now superseded by the new counter.

## Motivation

The existing `res_quantity_by_user_count` gauge used an in-memory map that reset on operator restart, making it unreliable for long-term tracking. It also only had a `user` label with no pool breakdown. The existing `successful_pool_reservations_total` was a Gauge being used as a counter (only `.Inc()`, never `.Set()` or `.Dec()`), also resetting on restart.

The new `reservations_by_requester_total` Counter replaces both:
- `sum by(requester) (reservations_by_requester_total)` replaces `res_quantity_by_user_count`
- `sum by(pool) (reservations_by_requester_total)` replaces `successful_pool_reservations_total`

It works correctly with Prometheus `rate()`/`increase()` and provides per-pool granularity per requester.

## Changes

### Metrics removed
- **`successful_pool_reservations_total`** -- Gauge used as counter, resets on restart
- **`res_quantity_by_user_count`** -- Gauge backed by in-memory map, resets on restart
- **`userNamespaceReservationCount`** -- in-memory map backing the above gauge

### Metric added
- **`reservations_by_requester_total`** -- Counter with labels `requester` and `pool`

### Go code
- `controllers/cloud.redhat.com/metrics.go`: Remove old metrics, add new counter
- `controllers/cloud.redhat.com/namespacereservation_controller.go`: Remove old metric calls, add counter increment
- `controllers/cloud.redhat.com/suite_test.go`: Remove tests for deleted metrics, add test for new metric

### Grafana dashboard
- Migrated "Successful Reservations" stat to use `reservations_by_requester_total`
- Migrated "Reservation Total By User" table to use `reservations_by_requester_total`
- Removed 4 panels that are superseded by the new panels:
  - Active Reservations by App (CI/Automation)
  - Top Apps by Active Reservations (CI/Automation)
  - Active Reservations by User (Stacked)
  - Top Users by Active Reservations
- Added 4 new panels:

| Panel | Type | Query |
|---|---|---|
| **Total Reservations by Requester** | table | `sort_desc(sum by(requester) (reservations_by_requester_total))` |
| **Top Requesters (All Time)** | bar gauge | `topk(10, sum by(requester) (reservations_by_requester_total))` |
| **Reservations by Pool** | pie chart | `sum by(pool) (reservations_by_requester_total)` |
| **Reservations per Hour by Pool** | time series | `sum by(pool) (increase(reservations_by_requester_total[1h]))` |

## Testing

- `make pre-push` passes (all 101 tests pass)
- Dashboard JSON validated as well-formed
- Net result: fewer metrics, fewer dashboard panels, better data quality