### PR TITLE
fix(dashboard): improve reservation metrics accuracy and consolidate panels

### DIFF
--- a/dashboards/ephemeral-ns-operator-dashboard.yaml
+++ b/dashboards/ephemeral-ns-operator-dashboard.yaml
@@ -653,104 +653,6 @@ data:
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 14
-          },
-          "id": 53,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.6.3",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "increase(namespace_reservation_duration_average_count{pool=\"default\", controller=\"namespacereservation\"}[1h])",
-              "legendFormat": "Reservations per hour",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Reservations per Hour (default pool)",
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
                 "axisLabel": "Reservations",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
@@ -795,8 +697,8 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 12,
+            "w": 24,
+            "x": 0,
             "y": 14
           },
           "id": 61,
@@ -826,7 +728,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum by(pool) (increase(reservations_by_requester_total[1h]))",
+              "expr": "sum by(pool) (increase(namespace_reservation_duration_average_count{controller=\"namespacereservation\"}[1h]))",
               "legendFormat": "{{pool}}",
               "range": true,
               "refId": "A"
@@ -876,6 +778,18 @@ data:
                     "value": "Total Reservations"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Time"
+                },
+                "properties": [
+                  {
+                    "id": "custom.hidden",
+                    "value": true
+                  }
+                ]
               }
             ]
           },
@@ -913,7 +827,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sort_desc(sum by(requester) (reservations_by_requester_total))",
+              "expr": "sort_desc(sum by(requester) (label_replace(reservations_by_requester_total, \"requester\", \"$1\", \"requester\", \"(.*)-[^-]+\")))",
               "format": "table",
               "instant": true,
               "legendFormat": "{{requester}}",
@@ -997,7 +911,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "topk(10, sum by(requester) (reservations_by_requester_total))",
+              "expr": "topk(10, sum by(requester) (label_replace(reservations_by_requester_total, \"requester\", \"$1\", \"requester\", \"(.*)-[^-]+\")))",
               "instant": true,
               "legendFormat": "{{requester}}",
               "range": false,

--- a/tests/grafana-preview/dashboard.json
+++ b/tests/grafana-preview/dashboard.json
@@ -642,104 +642,6 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 14
-      },
-      "id": 53,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.3",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "increase(namespace_reservation_duration_average_count{pool=\"default\", controller=\"namespacereservation\"}[1h])",
-          "legendFormat": "Reservations per hour",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Reservations per Hour (default pool)",
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
             "axisLabel": "Reservations",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -784,8 +686,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 24,
+        "x": 0,
         "y": 14
       },
       "id": 61,
@@ -815,7 +717,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(pool) (increase(reservations_by_requester_total[1h]))",
+          "expr": "sum by(pool) (increase(namespace_reservation_duration_average_count{controller=\"namespacereservation\"}[1h]))",
           "legendFormat": "{{pool}}",
           "range": true,
           "refId": "A"
@@ -865,6 +767,18 @@
                 "value": "Total Reservations"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
           }
         ]
       },
@@ -902,7 +816,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sort_desc(sum by(requester) (reservations_by_requester_total))",
+          "expr": "sort_desc(sum by(requester) (label_replace(reservations_by_requester_total, \"requester\", \"$1\", \"requester\", \"(.*)-[^-]+\")))",
           "format": "table",
           "instant": true,
           "legendFormat": "{{requester}}",
@@ -986,7 +900,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "topk(10, sum by(requester) (reservations_by_requester_total))",
+          "expr": "topk(10, sum by(requester) (label_replace(reservations_by_requester_total, \"requester\", \"$1\", \"requester\", \"(.*)-[^-]+\")))",
           "instant": true,
           "legendFormat": "{{requester}}",
           "range": false,

--- a/tests/grafana-preview/mock-metrics.py
+++ b/tests/grafana-preview/mock-metrics.py
@@ -5,6 +5,7 @@ panels render with meaningful values when running locally.
 """
 
 import random
+import string
 import time
 import threading
 from prometheus_client import (
@@ -18,10 +19,20 @@ from prometheus_client import (
 # -- Configuration ----------------------------------------------------------
 
 POOLS = ["default", "minimal", "minimal-secure", "managed-kafka"]
-REQUESTERS = [
-    "bsquizza", "jdoe", "asmith", "platform-ci", "qe-team",
-    "inventory-service", "advisor-service", "vulnerability-engine",
-    "compliance-backend", "ros-backend", "patch-service",
+HUMAN_REQUESTERS = [
+    "jdoe", "asmith", "mjones",
+]
+# CI job requesters with trailing UIDs (the dashboard strips the last segment)
+CI_REQUESTER_PREFIXES = [
+    "insights-hbi-smoke",
+    "insights-hbi-rbac",
+    "insights-hbi-all",
+    "bonfire-component-tests-pipelinerun",
+    "bonfire-integration-tests-pipelinerun",
+    "rbac-bonfire-tekton",
+    "compliance-backend-bonfire-tekton",
+    "koku-ci",
+    "content-sources-backend-bonfire-tekton",
 ]
 CONTROLLERS = ["clowdenvironment", "namespacepool", "namespacereservation"]
 REST_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "LIST", "WATCH"]
@@ -117,6 +128,16 @@ capi_cleanup_duration = Gauge(
 )
 
 
+def random_uid():
+    return "".join(random.choices(string.ascii_lowercase + string.digits, k=5))
+
+
+def random_requester():
+    if random.random() < 0.15:
+        return random.choice(HUMAN_REQUESTERS)
+    return f"{random.choice(CI_REQUESTER_PREFIXES)}-{random_uid()}"
+
+
 # -- Seed initial state -----------------------------------------------------
 
 def seed():
@@ -125,11 +146,10 @@ def seed():
     for pool in POOLS:
         failed_pool_reservations.labels(pool=pool).set(random.randint(0, 3))
 
-    for req in REQUESTERS:
+    for _ in range(80):
+        req = random_requester()
         pool = random.choice(POOLS)
-        reservations_by_requester.labels(requester=req, pool=pool).inc(
-            random.randint(5, 120)
-        )
+        reservations_by_requester.labels(requester=req, pool=pool).inc(1)
 
     active_reservations.labels(controller="namespacereservation").set(
         random.randint(3, 15)
@@ -176,8 +196,8 @@ def update_loop():
     while True:
         time.sleep(5)
 
-        # Simulate new reservations trickling in
-        req = random.choice(REQUESTERS)
+        # Simulate new reservations trickling in (with unique CI UIDs)
+        req = random_requester()
         pool = random.choice(POOLS)
         reservations_by_requester.labels(requester=req, pool=pool).inc(1)
 
@@ -219,8 +239,8 @@ def update_loop():
                 service="ephemeral-namespace-operator-controller-metrics-non-auth",
             ).set(random.randint(0, 5))
 
-        # Occasional new reservation duration observation
-        if random.random() < 0.3:
+        # Record reservation duration (drives 'Reservations per Hour by Pool')
+        if random.random() < 0.6:
             pool = random.choice(POOLS)
             hours = random.choice([1, 1, 2, 4, 8, 24])
             reservation_duration.labels(


### PR DESCRIPTION
## Summary
- **Fix 'Reservations per Hour by Pool' showing ~2 instead of actual count**: The panel was querying `reservations_by_requester_total` which has a unique time series per CI job run (265+ series, each stuck at value 1). Prometheus `increase()` returned ~0 per series since they never changed after creation. Switched to `namespace_reservation_duration_average_count` which accumulates into a single counter per pool.
- **Remove redundant 'Reservations per Hour (default pool)' panel**: The by-pool panel already covers all pools including default. Expanded the remaining panel to full width.
- **Consolidate CI job requesters in 'Top Requesters' and 'Total Reservations by Requester'**: CI jobs like `insights-hbi-rbac-glqkg`, `insights-hbi-rbac-5cvq6` are now grouped under `insights-hbi-rbac` using `label_replace` to strip trailing UIDs.
- **Hide useless Time column** from the 'Total Reservations by Requester' table.
- **Update mock metrics** to generate CI-style requester names with trailing UIDs so the `label_replace` consolidation is visible in local dashboard preview.

## Test plan
- [ ] Verify 'Reservations per Hour by Pool' shows accurate hourly rates matching actual reservation volume
- [ ] Verify 'Top Requesters' bar chart consolidates CI job runs under their base name
- [ ] Verify 'Total Reservations by Requester' table no longer shows a Time column
- [ ] Run local dashboard preview (`tests/grafana-preview/`) and confirm panels render with mock data

🤖 Generated with [Claude Code](https://claude.com/claude-code)