### PR TITLE
fix(metrics): backfill reservation counters on operator startup

### DIFF
--- a/controllers/cloud.redhat.com/poller.go
+++ b/controllers/cloud.redhat.com/poller.go
@@ -74,6 +74,7 @@ func (p *Poller) populateActiveReservations(ctx context.Context) error {
 	for _, res := range resList.Items {
 		if res.Status.State == "active" {
 			p.activeReservations[res.Name] = res.Status.Expiration
+			reservationsByRequesterTotalMetrics.With(prometheus.Labels{"requester": res.Spec.Requester, "pool": res.Status.Pool}).Inc()
 			p.log.Info("Added active reservation to poller", "res-name", res.Name)
 		}
 	}


### PR DESCRIPTION
## Summary
- Backfill `reservations_by_requester_total` counter in `populateActiveReservations()` on operator startup so the dashboard "Total Reservations by Requester" and "Top Requesters (All Time)" panels show accurate data after a pod restart
- Root cause: the counter resets to zero on restart, and existing active reservations are re-reconciled through the `case "active"` branch which does not increment this counter — only brand-new reservations (`default` case) do

## Test plan
- [x] `make pre-push` passes (fmt, vet, all 39 tests)
- [ ] Deploy to cluster and verify `reservations_by_requester_total` is populated immediately after pod startup
- [ ] Confirm dashboard panels show complete requester data without waiting for new reservations

🤖 Generated with [Claude Code](https://claude.com/claude-code)