### PR TITLE
fix: handle not-found error during CAPI cleanup finalizer removal

### DIFF
--- a/controllers/cloud.redhat.com/namespacereservation_controller.go
+++ b/controllers/cloud.redhat.com/namespacereservation_controller.go
@@ -322,6 +322,10 @@ func (r *NamespaceReservationReconciler) handleCAPICleanup(ctx context.Context, 
 
 	controllerutil.RemoveFinalizer(res, capiCleanupFinalizer)
 	if err := r.client.Update(ctx, res); err != nil {
+		if k8serr.IsNotFound(err) {
+			log.Info("reservation already deleted, skipping finalizer removal", "res-name", res.Name)
+			return ctrl.Result{}, nil
+		}
 		log.Error(err, "could not remove CAPI cleanup finalizer", "res-name", res.Name)
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
## Summary
- Handle race condition where a reservation is deleted (by the poller) while `handleCAPICleanup` is still running
- When the finalizer removal `Update` returns "not found", treat it as success instead of logging an error and requeueing indefinitely
- The reservation and its finalizer are already gone, so there's nothing left to do

## Context
Observed in production logs:
```
INFO  All CAPI resources removed, releasing finalizer  {"namespace": "ephemeral-t0m9ji"}
ERROR could not remove CAPI cleanup finalizer  {"error": "namespacereservations.cloud.redhat.com \"bonfire-reservation-85879990\" not found"}
```

## Test plan
- [x] `make pre-push` passes (fmt, vet, all 39 tests)
- [ ] Verify error no longer appears in operator logs when reservations expire during CAPI cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)