### PR TITLE
Renovate: group all PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
 	"extends": [
 		":disableMajorUpdates",
 		":group:kubernetesMonorepo",
-		"github>konflux-ci/mintmaker-presets:cve-automerge-all"
+		"github>konflux-ci/mintmaker-presets:cve-automerge-all",
+		"group:all"
 	],
 	"dockerfile": {
 		"managerFilePatterns": [


### PR DESCRIPTION
Add 'group:all' to cause renovate to group all dependency update PRs into a single PR